### PR TITLE
Typo correction - Lookup page: a7c3a810-28c8-4b47-96a6-8156b1524af3.md

### DIFF
--- a/docs/notes/a7c3a810-28c8-4b47-96a6-8156b1524af3.md
+++ b/docs/notes/a7c3a810-28c8-4b47-96a6-8156b1524af3.md
@@ -242,8 +242,8 @@ Dendron has builtin notion for certain types of notes with [pre-defined hierarch
 
 - values:
   - none (default): create a regular note
-  - journal: create a journal note (cmd/ctrl + shift + s)
-  - scratch: create a scratch note (cmd/ctrl + shift + j)
+  - journal: create a journal note (cmd/ctrl + shift + j)
+  - scratch: create a scratch note (cmd/ctrl + shift + s)
 
 
 


### PR DESCRIPTION
Small typo where the shortcuts for creating a journal and scratch note were reversed. Tested locally and compared with cheatsheet.