### PR TITLE
Update dendron.guides.migration.md

### DIFF
--- a/vault/dendron.guides.migration.md
+++ b/vault/dendron.guides.migration.md
@@ -18,3 +18,12 @@ This note covers migrating your notes from other tools
 1. [Convert one note files to markdown](https://itectec.com/superuser/how-to-export-all-onenote-pages-to-individual-markdown-files/)
 2. Use the [[markdown pod|dendron.topic.pod.builtin.markdown]] to import your notes into Dendron
 
+## Importing Files
+
+Once Dendron is initialized, to import an individual markdown file to your Dendron project.
+
+1. drag the markdown file into VSCode
+2. run `Dendron Doctor`so Dendron recognizes the imported file. 
+
+The second step will add some front matter to the head of the file.
+


### PR DESCRIPTION
There should probably be an importing markdown files TOC entry, but for now, this seems like it's an improvement. 

Rationale: For users like myself who are dipping their toes in the water, testing out Dendron vs Foam, vs other similar projects, having a simple way to drag in an existing markdown file to just try it out is a great help. 

Dendron has interesting concepts, but as a user, what I really care about at second zero, is "Does this work? How easy is it to get started compared to the other options?"

Having to learn about `dendron pod import markdown` and set up the `import config` to import a file feels pretty heavy. Knowing you could just drag something in, and run doctor and start linking things seems more convenient.