### PR TITLE
Update dendron.topic.publishing.configuration.md

### DIFF
--- a/vault/dendron.topic.publishing.configuration.md
+++ b/vault/dendron.topic.publishing.configuration.md
@@ -239,7 +239,7 @@ You can control publication on a per line basis.
 
 ### LOCAL_ONLY_LINE
 
-Sometimes, you just want to keep a few lines private while publishing the rest of your vault. You can do that with `Local only`. In order to mark a line as `Local Only`, add the following markdown comment at the end of the line: `<!--LOCAL_ONLY_LINE-->`
+Sometimes, you just want to keep a few lines private while publishing the rest of your vault. You can do that with `Local only`. In order to mark a line as `Local Only`, add the following markdown comment at the end of the line: 
 
 ```markdown
 Hello World!  <!-- Will be published -->


### PR DESCRIPTION
<!--LOCAL_ONLY_LINE--> is great. But it is also preventing the example to be published. If that was the intention, then its cool. But I think we should print these lines.
I am not sure how we can display it on the site for now.

I have removed it just to suggest an improvement.