### PR TITLE
broken transclusion from dendron.reference.layout

### DIFF
--- a/vault/dendron.topic.hierarchies.md
+++ b/vault/dendron.topic.hierarchies.md
@@ -40,7 +40,7 @@ The same hierarchy in Dendron would look like the following:
 
 In the following concepts, we will be using the following file tree
 
-((ref:[[dendron.ref.layout]]#File Tree,1:#Files))
+((ref:[[dendron.ref.layout]]#File Tree,1:#Additional Folders))
 
 ### Root
 


### PR DESCRIPTION
referenced heading `#Files` when there was none leading to a broken transclusion.

![image](https://user-images.githubusercontent.com/29872822/107487468-0a996680-6b3b-11eb-9ef7-9fa22aa801d8.png)
![image](https://user-images.githubusercontent.com/29872822/107487503-14bb6500-6b3b-11eb-9ea8-f59396d359d8.png)
