### PR TITLE
Extend frontmatter topic with more note configs

### DIFF
--- a/vault/dendron.topic.frontmatter.md
+++ b/vault/dendron.topic.frontmatter.md
@@ -2,7 +2,7 @@
 id: ffec2853-c0e0-4165-a368-339db12c8e4b
 title: Frontmatter
 desc: ''
-updated: 1595352354163
+updated: 1614665377409
 created: 1595352354163
 stub: false
 ---
@@ -62,3 +62,6 @@ this is reserved for internal use
 
 this is reserved for internal use
 
+# Other keys
+
+((ref:[[dendron.topic.publishing.configuration]]#Note Configuration))


### PR DESCRIPTION
I recently was looking for the `date` key/value for note frontmatter, and found it on a different page than I was expecting.

This change extends the `dendron-site/vault/dendron.topic.frontmatter.md` note with:

```
((ref:[[dendron.topic.publishing.configuration]]#Note Configuration))
```