### PR TITLE
Clarify scratch note name format example

### DIFF
--- a/vault/dendron.topic.special-notes.md
+++ b/vault/dendron.topic.special-notes.md
@@ -31,7 +31,7 @@ A reference for date formatting tokens can be found [here](https://moment.github
 
 ## Scratch Note
 
-A scratch note is a self contained note that is meant to be used as scratchpad. Use it for thoughts or when you want to expand on a bullet point. Scratch notes are created in the `scratch` domain and have the following format: `{domain}.journal.{y.MM.dd.HHmmss}`. 
+A scratch note is a self contained note that is meant to be used as scratchpad. Use it for thoughts or when you want to expand on a bullet point. Scratch notes are created in the `scratch` domain and have the following format: `scratch.{y.MM.dd.HHmmss}`. 
 
 <a href="https://www.loom.com/share/2fd3042119124df8bb4592d8ffe6d708"> 
 <img style="" src="https://cdn.loom.com/sessions/thumbnails/2fd3042119124df8bb4592d8ffe6d708-with-play.gif"> </a>


### PR DESCRIPTION
Remove `{domain}` tag and `journal` node from the example generated scratch note name