### PR TITLE
New note ref caveats with github-slugging

### DIFF
--- a/vault/dendron.release.changelog.0-1-x.md
+++ b/vault/dendron.release.changelog.0-1-x.md
@@ -2,7 +2,7 @@
 id: ed4162aa-5474-4483-9fbc-c0b505310c59
 title: 0.1.X
 desc: ''
-updated: 1614924050223
+updated: 1615427862023
 created: 1610397097347
 ---
 ## 0.19.3
@@ -832,8 +832,9 @@ Current Seeds:
 - open AWS catalogue
 ```
 
-((ref:[[dendron.community.showcase]]#open pkm catalogue,1:#*))
-((ref:[[dendron.community.showcase]]#open aws catalogue,1:#*))
+![[dendron.community.showcase#open-pkm-catalogue,1:#*]]
+
+![[dendron.community.showcase#Open-AWS-Catalogue,1:#*]]
 
 #### Alternatives
 

--- a/vault/dendron.topic.refs.md
+++ b/vault/dendron.topic.refs.md
@@ -2,7 +2,7 @@
 id: f1af56bb-db27-47ae-8406-61a98de6c78c
 title: References
 desc: ''
-updated: 1614057759268
+updated: 1615430357861
 created: 1597356582509
 stub: false
 ---
@@ -14,16 +14,25 @@ Currently, Dendron supports 3 types of references:
 - block references
 - block range references
 
-References have the following syntax
+References have the following syntax:
 
 ```
-![[ NAME_OF_NOTE 
-    #STARTING_HEADER                            # optional
-    :#ENDING_HEADER                             # optional
-]]
+![[NAME.OF.NOTE]]
 ```
 
-- NOTE: Dendron recently switched the note ref syntax for `((ref: [[foo]]))` to `![[foo]]`. The videos have not yet been updated to reflect this change
+Another example with a header range:
+
+```
+![[NAME.OF.NOTE#STARTING-HEADER:#ENDING-HEADER]]
+```
+
+> NOTE: When referencing headers with spaces in them, the note ref needs to use `-` instead of spaces within the name. This is a limitation of adopting GitHub-style slugger references. This is also useful for when multiple subheaders on a page may have the same name, which would expect something else `#foo` vs. `#foo-1` vs. `#foo-2`. This can be automatically taken care of by highlighting a header, and using `cmd+shift+r` / `ctrl+shift+r` to add a properly-formatted note ref to the clipboard.
+>
+> For more information:
+> - [StackOverflow: How to escape symbols in GitHub-flavored markdown internal links / heading anchors?](https://stackoverflow.com/a/48760076/5340149)
+> - [Anchors in Markdown gist](https://gist.github.com/asabaylus/3071099)
+
+> NOTE: Dendron recently switched the note ref syntax for `((ref: [[foo]]))` to `![[foo]]`. The videos have not yet been updated to reflect this change.
 
 ## Configuration
 


### PR DESCRIPTION
Fixes https://github.com/dendronhq/dendron-site/issues/65

It does not update all of the note references following the old approach, which I have audited and commented in the above issue discussion.