### PR TITLE
Updates the package versions

### DIFF
--- a/vault/dendron.topic.publishing.github.md
+++ b/vault/dendron.topic.publishing.github.md
@@ -39,8 +39,8 @@ git checkout main
   },
   "license": "CC BY 4.0",
   "devDependencies": {
-    "@dendronhq/dendron-11ty": "^1.24.4",
-    "@dendronhq/dendron-cli": "^0.24.0"
+    "@dendronhq/dendron-11ty": "^1.32.0",
+    "@dendronhq/dendron-cli": "^0.32.0"
   }
 }
 ```


### PR DESCRIPTION
A module dep issue was affecting the export to gh-pages builds.

Looks like the docs were a major version behind the current releases and there were some dependency issues with those versions. 

Fixed the issue locally by updating the versions to the latest available. 

I've not tested the actions yet, but that's next on the list.