### PR TITLE
Add paste image extension link

### DIFF
--- a/vault/dendron.topic.images.md
+++ b/vault/dendron.topic.images.md
@@ -8,7 +8,7 @@ stub: false
 ---
 ## Copy & Paste
 
-Dendron automatically inserts images in your clipboard using the `> Paste Image` command. The image is saved to `${currentFileDir}/assets` by default. This feature requires the [Paste Image]([Dendron Paste Image](https://marketplace.visualstudio.com/items?itemName=dendron.dendron-paste-image)) VSCode extension.
+Dendron automatically inserts images in your clipboard using the `> Paste Image` command. The image is saved to `${currentFileDir}/assets` by default. This feature requires the [Paste Image](https://marketplace.visualstudio.com/items?itemName=dendron.dendron-paste-image) VSCode extension.
 
 <a href="https://www.loom.com/share/e1f6d207a1134f42b7a1a7750658acec">
 <img style="" src="https://cdn.loom.com/sessions/thumbnails/e1f6d207a1134f42b7a1a7750658acec-with-play.gif"> </a>

--- a/vault/dendron.topic.images.md
+++ b/vault/dendron.topic.images.md
@@ -8,7 +8,7 @@ stub: false
 ---
 ## Copy & Paste
 
-Dendron automatically inserts images in your clipboard using the `> Paste Image` command. The image is saved to `${currentFileDir}/assets` by default.
+Dendron automatically inserts images in your clipboard using the `> Paste Image` command. The image is saved to `${currentFileDir}/assets` by default. This feature requires the [Paste Image](https://marketplace.visualstudio.com/items?itemName=mushan.vscode-paste-image) VSCode extension.
 
 <a href="https://www.loom.com/share/e1f6d207a1134f42b7a1a7750658acec">
 <img style="" src="https://cdn.loom.com/sessions/thumbnails/e1f6d207a1134f42b7a1a7750658acec-with-play.gif"> </a>

--- a/vault/dendron.topic.images.md
+++ b/vault/dendron.topic.images.md
@@ -8,7 +8,7 @@ stub: false
 ---
 ## Copy & Paste
 
-Dendron automatically inserts images in your clipboard using the `> Paste Image` command. The image is saved to `${currentFileDir}/assets` by default. This feature requires the [Paste Image](https://marketplace.visualstudio.com/items?itemName=mushan.vscode-paste-image) VSCode extension.
+Dendron automatically inserts images in your clipboard using the `> Paste Image` command. The image is saved to `${currentFileDir}/assets` by default. This feature requires the [Paste Image]([Dendron Paste Image](https://marketplace.visualstudio.com/items?itemName=dendron.dendron-paste-image)) VSCode extension.
 
 <a href="https://www.loom.com/share/e1f6d207a1134f42b7a1a7750658acec">
 <img style="" src="https://cdn.loom.com/sessions/thumbnails/e1f6d207a1134f42b7a1a7750658acec-with-play.gif"> </a>


### PR DESCRIPTION
Hello,
I want to add a small emphasis that this feature is not available automatically. Started to work with Dendron and neither the `dendron.md` nor the Page it links to states that a VSCode plugin is needed. I think it helps to make these things more obvious otherwise it quickly leads to frustration.