### PR TITLE
Help beginners with Note References

### DIFF
--- a/vault/dendron.tutorial.links.md
+++ b/vault/dendron.tutorial.links.md
@@ -125,6 +125,7 @@ Now highlight the first header and use `CMD|CTRL+SHIFT+R` to create another note
 Go back to `pro.skynet`. Notice how the note ref has updated with the latest text. 
 
 Now copy your newly created reference and paste it underneath.
+- BE CAREFUL - some methods of selecting the line will put an extra space after the work "more!". We don't want that space. Make sure that what's highlighted is just all the text from "##" to "more!"
 - notice that the newly created reference only has the contents from the newly created header
 - notice that the newly created reference doesn't show the actual header itself (you can change this behavior by removing the `,1` inside the reference)
 


### PR DESCRIPTION
Added 
```
- BE CAREFUL - some methods of selecting the line will put an extra space after the work "more!". We don't want that space. Make sure that what's highlighted is just  the text from "##" to "more!"
```

Selecting the header for a note reference has to be done carefully so it doesn't include an extra char at the end of the line. Triple clicking includes the extra character and CMD-SPACE-R will just give ![[the_note]], not ![[the_not#with-the-header,1:#*]].
the VIM emulation (dd + P) does this too.
CTRL-CMD-SPACE and right-arrow x 2 doesn't (just selects the text)
I have a short screen cast if that would help.