### PR TITLE
Add a link to the 11ty site

### DIFF
--- a/vault/dendron.topic.publishing.quickstart.preview-your-site.md
+++ b/vault/dendron.topic.publishing.quickstart.preview-your-site.md
@@ -65,7 +65,7 @@ The following describes how to prepare your notes for publication using [[Dendro
 
 ### Setup
 
-In order to to use the 11ty based publishing, initialize your workspace with the following commands.
+In order to to use the [11ty](https://www.11ty.dev/) based publishing, initialize your workspace with the following commands.
 
 ```bash
 npm init -y


### PR DESCRIPTION
The link makes the page more useful to people like me who are not familiar with 11ty. Also, 11ty by itself looks like a typo.