### PR TITLE
Changed `.tags.` into `tag.`

### DIFF
--- a/vault/dendron.guides.tips.md
+++ b/vault/dendron.guides.tips.md
@@ -56,7 +56,7 @@ If you use links for tags: `[[#business|books.tags.business]]`, you can use this
 
 ```css
 /* General tag styling */
-a[href*=".tags."] {
+a[href*="tag."] {
     color: #000;
     background: #fff;
     display: inline-block;


### PR DESCRIPTION
Since the default syntax for tags through the `#` snippet is `tag.your-tag`, it will be more appropriate to change the tag coloring in the wiki to this as well.