### PR TITLE
Fix pod development documentation

### DIFF
--- a/vault/dendron.topic.pod.dev.md
+++ b/vault/dendron.topic.pod.dev.md
@@ -2,7 +2,7 @@
 id: 5de219e6-d9b9-4abf-9367-998109cd57cd
 title: Developing a Pod
 desc: ''
-updated: 1620596198550
+updated: 1622045743569
 created: 1614201272488
 ---
 ## Summary
@@ -71,9 +71,10 @@ module.exports = {
    ```
 5. Excecute your pod
    ```sh
-   dendron-cli publishPod --wsRoot . --podId hello --podPkg hello-pod --podSource remote --config fname=dendron,vaultName=vault,dest=stdout
+   dendron-cli publishPod --wsRoot . --podId hello --podPkg hello-pod --podSource custom --config fname=dendron,vaultName=vault,dest=stdout
    ```
-   - since I was running this in a new Dendron vault, I got the following output
+   - since I was running this in a new Dendron vault, I got the following output.
+   - you can change the value of the fname config to an existing note's file name to run it against that note.
 
 ```markdown
 Hello World


### PR DESCRIPTION
This PR:
- fixes an incorrect codeblock for running the custom publishPod.
- explicitly state that you can pass in an fname through config.