### PR TITLE
Rename Command Bar to Command Palette

### DIFF
--- a/vault/dendron.concepts.md
+++ b/vault/dendron.concepts.md
@@ -2,7 +2,7 @@
 id: c6fd6bc4-7f75-4cbb-8f34-f7b99bfe2d50
 title: Concepts
 desc: ''
-updated: 1622842184739
+updated: 1623921386025
 created: 1595169512265
 nav_order: 3
 ---
@@ -87,9 +87,9 @@ There are two reasons why these suggested notes might show up:
 
 [[Pods|dendron.topic.pod]] are the mechanisms Dendron uses to import and export notes. Dendron has a different pod depending on where you are getting and publishing your data to. 
 
-### Command Bar
+### Command Palette
 
-The command bar is native to `vscode`. You can use it to run dendron commands, which will all be prefixed with `Dendron:`. You can use the following shortcut to open the command bar. 
+The command palette is native to `vscode`. You can use it to run dendron commands, which will all be prefixed with `Dendron:`. You can use the following shortcut to open the command palette.
 
 - <img src="https://www.kernel.org/theme/images/logos/favicon.png" width=16 height=16/> <a href="https://code.visualstudio.com/shortcuts/keyboard-shortcuts-linux.pdf">Linux</a> `Ctrl+Shift+P`
 - <img src="https://developer.apple.com/favicon.ico" width=16 height=16/> <a href="https://code.visualstudio.com/shortcuts/keyboard-shortcuts-macos.pdf">macOS</a> `Cmd+Shift+P`
@@ -97,7 +97,7 @@ The command bar is native to `vscode`. You can use it to run dendron commands, w
 
 ### Lookup Bar
 
-The lookup bar is how you interact with notes inside of Dendron. Use it to create, find, and delete notes. You can type `> Dendron: Lookup` in the `Command Bar` or use the `Ctrl+L` shortcut. 
+The lookup bar is how you interact with notes inside of Dendron. Use it to create, find, and delete notes. You can type `> Dendron: Lookup` in the `Command Palette` or use the `Ctrl+L` shortcut. 
 
 - <img src="https://www.kernel.org/theme/images/logos/favicon.png" width=16 height=16/> <a href="https://code.visualstudio.com/shortcuts/keyboard-shortcuts-linux.pdf">Linux</a> `Ctrl+L`
 - <img src="https://developer.apple.com/favicon.ico" width=16 height=16/> <a href="https://code.visualstudio.com/shortcuts/keyboard-shortcuts-macos.pdf">macOS</a> `Cmd+L`

--- a/vault/dendron.faq.md
+++ b/vault/dendron.faq.md
@@ -2,7 +2,7 @@
 id: 683740e3-70ce-4a47-a1f4-1f140e80b558
 title: FAQ
 desc: ""
-updated: 1623595726299
+updated: 1623921386028
 created: 1595952505025
 stub: false
 nav_order: 6
@@ -91,7 +91,7 @@ For more context, you can see the original markdown declaration [here](https://d
 
 You can use Dendron with existing repositories of markdown notes.
 
-Open the `Command Bar` in vscode and use the `Dendron: Change Workspace` command. It will ask you for a folder path as input.
+Open the `Command Palette` in vscode and use the `Dendron: Change Workspace` command. It will ask you for a folder path as input.
 
 Dendron will create a `dendron.code-workspace` file in specified directory and then open the workspace (if a workspace file already exists, it will use that). It will also create a `root.md` file in that directory if it doesn't exist (currently this is part of the internal working of dendron).
 

--- a/vault/dendron.guides.cook.md
+++ b/vault/dendron.guides.cook.md
@@ -2,7 +2,7 @@
 id: 401c5889-20ae-4b3a-8468-269def4b4865
 title: Cookbook
 desc: ""
-updated: 1622804242841
+updated: 1623921352199
 created: 1595952505024
 nav_order: 8.9
 toc: true
@@ -36,7 +36,7 @@ You can get logs of the previous session by following instructions [here](https:
 
 Dendron doesn't currently provide native support for this. You can download the [Bookmarks](https://marketplace.visualstudio.com/items?itemName=alefragnani.Bookmarks) extension to achieve the functionality in the interim.
 
-### Launch the command bar
+### Launch the command palette
 
 This lets you execute commands inside vscode
 

--- a/vault/dendron.guides.install.md
+++ b/vault/dendron.guides.install.md
@@ -2,7 +2,7 @@
 id: d95b93bf-5e6f-4dd0-b7d7-c8e29e061876
 title: Install Dendron
 desc: ''
-updated: 1620596297783
+updated: 1623981567828
 created: 1595537796868
 ---
 
@@ -12,11 +12,11 @@ After you have downloaded the plugin, following the instructions to create your 
 
 ## Initialize your workspace
 
-1. With VSCode in focus, launch the _command bar_:
+1. With VSCode in focus, launch the _command palette_:
 
-![[dendron.guides.cook#launch-the-command-bar,1:#*]]
+![[dendron.guides.cook#launch-the-command-palette,1:#*]]
 
-2. Paste the following command and press `Enter`: 
+2. Paste the following command and press `Enter`:
 
 ```bash
 > Dendron: Initialize Workspace

--- a/vault/dendron.release.2020-08-02.md
+++ b/vault/dendron.release.2020-08-02.md
@@ -2,7 +2,7 @@
 id: e32aa1e2-9780-4183-927e-2f46372050aa
 title: Release Notes(version 0.5)
 desc: ''
-updated: 1609990774348
+updated: 1623981566779
 created: 1596374984386
 date: '2020-08-02'
 ---
@@ -20,7 +20,7 @@ These release notes are summary of the more notable changes, for the full list, 
 
 ## Commands
 
-Dendron has a series of built-in commands. They are all prefixed with `Dendron:` and can be accessed through the [command prompt](https://www.dendron.so/notes/c6fd6bc4-7f75-4cbb-8f34-f7b99bfe2d50.html#command-bar).
+Dendron has a series of built-in commands. They are all prefixed with `Dendron:` and can be accessed through the [command prompt](https://www.dendron.so/notes/c6fd6bc4-7f75-4cbb-8f34-f7b99bfe2d50.html#command-palette).
 
 ### Add Doctor Command
 

--- a/vault/dendron.topic.graph-view.md
+++ b/vault/dendron.topic.graph-view.md
@@ -2,7 +2,7 @@
 id: 587e6d62-3c5b-49b0-aedc-02f62f0448e6
 title: Graph View
 desc: ""
-updated: 1623699810447
+updated: 1623981565964
 created: 1595120707814
 stub: false
 ---
@@ -18,7 +18,7 @@ stub: false
 
 ### Show Note Graph V2
 
-Launch the command bar (see [[docs|dendron.guides.cook#launch-the-command-bar]]): `> Dendron: Show Note Graph V2`
+Launch the command palette (see [[docs|dendron.guides.cook#launch-the-command-palette]]): `> Dendron: Show Note Graph V2`
 
 Click on a node to open up the corresponding note in your workspace.
 
@@ -26,7 +26,7 @@ The note graph currently only supports hierarchical note connections. Future ver
 
 ### Show Schema Graph V2
 
-Launch the command bar (see [[docs|dendron.guides.cook#launch-the-command-bar]]): `> Dendron: Show Schema Graph V2`
+Launch the command palette (see [[docs|dendron.guides.cook#launch-the-command-palette]]): `> Dendron: Show Schema Graph V2`
 
 Click on a node to open up the corresponding schema in your workspace.
 

--- a/vault/dendron.topic.graph-view.prune.md
+++ b/vault/dendron.topic.graph-view.prune.md
@@ -2,7 +2,7 @@
 id: hEDGu1KqxTsSUASO2gW6U
 title: Prune
 desc: ''
-updated: 1623699891291
+updated: 1623981563971
 created: 1623699719673
 ---
 
@@ -21,7 +21,7 @@ Note that this command is not optimized for performance and you might notice slo
 
 #### Dendron: Show Note Graph
 
-Launch the command bar (see [link](https://www.dendron.so/notes/401c5889-20ae-4b3a-8468-269def4b4865.html#launch-the-command-bar) for info): `> Dendron: Show Note Graph`
+Launch the command palette (see [link](https://www.dendron.so/notes/401c5889-20ae-4b3a-8468-269def4b4865.html#launch-the-command-palette) for info): `> Dendron: Show Note Graph`
 
 Show your note hierarchies visually in a graph.
 
@@ -29,7 +29,7 @@ Show your note hierarchies visually in a graph.
 
 #### Dendron: Show Schema Graph
 
-Launch the command bar (see [link](https://www.dendron.so/notes/401c5889-20ae-4b3a-8468-269def4b4865.html#launch-the-command-bar) for info): `> Dendron: Show Schema Graph`
+Launch the command palette (see [link](https://www.dendron.so/notes/401c5889-20ae-4b3a-8468-269def4b4865.html#launch-the-command-palette) for info): `> Dendron: Show Schema Graph`
 
 Show your note schemas visually in a graph. Schemas will be labelled by their `title` attribute. If `title` is not set, default to its `id`.
 

--- a/vault/dendron.topic.lookup.delete.md
+++ b/vault/dendron.topic.lookup.delete.md
@@ -2,8 +2,8 @@
 id: a6f1d6c7-91f3-4c14-9b89-9e66b6276f70
 title: Deleting Notes
 desc: ''
-updated: 1608494857196
+updated: 1623921386030
 created: 1608494673903
 ---
-To delete `dendron.lookup.hello`, use the `Cmd+Shift+D` shortcut on the note that you want to delete. Alternatively, you can also launch the `Command Bar` and type `Dendron: Delete Node` 
+To delete `dendron.lookup.hello`, use the `Cmd+Shift+D` shortcut on the note that you want to delete. Alternatively, you can also launch the `Command Palette` and type `Dendron: Delete Node` 
 

--- a/vault/dendron.topic.special-notes.md
+++ b/vault/dendron.topic.special-notes.md
@@ -2,18 +2,18 @@
 id: 5c213aa6-e4ba-49e8-85c5-1bdcb33ce202
 title: Special Notes
 desc: ""
-updated: 1621568510916
+updated: 1623920590655
 created: 1595004457029
 stub: false
 ---
 
-Dendron has builtin support for a variety of special note formats. These notes can be created using regular lookup - these commands provide convenient shortcuts for frequently used notes.
+Dendron has built-in support for a variety of special note formats. These notes can be created using regular lookup - these commands provide convenient shortcuts for frequently used notes.
 
 ## Daily Journal
 
 One of the most common ways of note taking is the daily journal.  
 
-You can create a daily journal using `> Dendron: Create Daily Journal Note`. You'll also see the corresponding keyboard shortcut for your operating system when you use this command. 
+You can create a daily journal by typing `> Dendron: Create Daily Journal Note` in the Command Palette. You'll also see the corresponding keyboard shortcut for your operating system when you use this command. 
 
 By default, it will create the journal under `daily.{date}` though this is configurable by setting the `dendron.dailyJournalDomain`.
 

--- a/vault/dendron.welcome.md
+++ b/vault/dendron.welcome.md
@@ -2,7 +2,7 @@
 id: 05774b2e-ebf7-4bbc-8171-ad191ba0ae0a
 title: "Welcome to Dendron \U0001F332"
 desc: ''
-updated: 1608485512294
+updated: 1623921360121
 created: 1598457956604
 stub: false
 nav_exclude: true
@@ -21,7 +21,7 @@ We call this the [hierarchy first approach](https://www.kevinslin.com/notes/3dd5
 
 ## How do I get started?
 
-1. Launch the _command bar_ inside vscode:
+1. Launch the _command palette_ inside vscode:
    - Linux: `Ctrl+Shift+P`
    - macOS: `Cmd+Shift+P`
    - Windows: `Ctrl+Shift+P`


### PR DESCRIPTION
To be a little more precise with our naming, this changes references to 'command bar' to 'command palette', which is the term VS Code uses: https://code.visualstudio.com/docs/getstarted/userinterface#_command-palette 