### PR TITLE
add section for gettin help in `dendron.dev.setup`

### DIFF
--- a/vault/dendron.dev.setup.md
+++ b/vault/dendron.dev.setup.md
@@ -2,7 +2,7 @@
 id: 64f0e2d5-2c83-43df-9144-40f2c68935aa
 title: Setup
 desc: ''
-updated: 1623432122509
+updated: 1623996396658
 created: 1598651458825
 ---
 
@@ -222,3 +222,11 @@ In case something something goes wrong with a build step or you want to save tim
 ### Husky Hooks not running
 
 Make sure you run `yarn` at the root of your workspace 
+
+## Getting Help
+
+Dendron is actively being developed and it could be quite confusing to start developing for the first time. In this case, we recommend asking for help with whatever blockers you might have with setting up or understanding part of the codebase.
+
+Generally, a member of the Dendron team or the community will chime in for help if you post a specific question in the `#dev` channel in our Discord server.
+
+For more information, check out our handbook entry on `Getting help for development` described [here](https://handbook.dendron.so/notes/bHWjVTtdOCMMRd2_QD0tb.html)


### PR DESCRIPTION
This PR:
- Adds a section describing how to get help setting up and understanding the codebase, and links to the SOP in our handbook.