### PR TITLE
fix: remove import to missing schema

### DIFF
--- a/vault/dendron.community.office-hours.2021.06.20.md
+++ b/vault/dendron.community.office-hours.2021.06.20.md
@@ -1,8 +1,8 @@
 ---
 id: CaBdm9dIdQrVNXW25ICmK
-title: office-hours-2021-06-20
+title: 20
 desc: ""
-updated: 1624288173484
+updated: 1624802166271
 created: 1624288131312
 ---
 

--- a/vault/dendron.schema.yml
+++ b/vault/dendron.schema.yml
@@ -1,6 +1,4 @@
 version: 1
-imports:
-  - pro
 schemas:
 - id: dendron
   parent: root
@@ -14,7 +12,6 @@ schemas:
     - topic
     - demo
     - dev
-    - pro.pro
 - id: faq
 - id: features
 - id: principles
@@ -30,7 +27,7 @@ schemas:
   namespace: true
   desc: "Major feature areas"
 - id: template
-  template: 
+  template:
     id: dendron.template.example
     type: note
 - id: dev


### PR DESCRIPTION
This caused a "schema malformed" error. In a previous commit `pro.schema.yml` has been renamed to `pkg.schema.yml`. 
Meaning also this  error happpens when an schema import does not exist. The error message did not include the schema file that was responsible for that which made it non-trivial to find out where to look for. We might want to allow this kind of error like @kevins8 mentioned and only message the user about it.