### PR TITLE
Update dendron.topic.publishing.quickstart.publishing-your-site.md

### DIFF
--- a/vault/dendron.topic.publishing.quickstart.publishing-your-site.md
+++ b/vault/dendron.topic.publishing.quickstart.publishing-your-site.md
@@ -93,7 +93,11 @@ In order to have Dendron generate your website, you open the Command Palette (`C
 
 ### Publish your notes
 
-Github will publish your notes everytime you push. Commit all your changes (`git add .` then `git commit`) and perform a `git push`.
+You open the Command Palette (`Cmd+Shift+P`) and use the [`Dendron: Worksapce: Sync`](https://wiki.dendron.so/notes/c4cf5519-f7c2-4a23-b93b-1c9a02880f6b.html#workspace-sync) command.
+
+Or you can calmly type in your terminal to commit all your changes (`git add .` then `git commit`) and perform a `git push`.
+
+GitHub will synchronize all changes and publish your notes everytime you push.
 
 ```bash
 git add .

--- a/vault/dendron.topic.publishing.quickstart.publishing-your-site.md
+++ b/vault/dendron.topic.publishing.quickstart.publishing-your-site.md
@@ -93,7 +93,7 @@ In order to have Dendron generate your website, you open the Command Palette (`C
 
 ### Publish your notes
 
-You open the Command Palette (`Cmd+Shift+P`) and use the [`Dendron: Worksapce: Sync`](https://wiki.dendron.so/notes/c4cf5519-f7c2-4a23-b93b-1c9a02880f6b.html#workspace-sync) command.
+You open the Command Palette (`Cmd+Shift+P`) and use the [[Workspace: Sync|dendron.topic.commands#workspace-sync]] command.
 
 Or you can calmly type in your terminal to commit all your changes (`git add .` then `git commit`) and perform a `git push`.
 


### PR DESCRIPTION
Add the instruction to use command `Dendron: Worksapce: Sync` next to `git add commit push`  chain in the last step. I'm not sure whether it simplify or give too much information for new user. But actually, as a non-tech user, I prefer to learn the existence of the command `Dendron: Worksapce: Sync` which is much simpler and intuitive to use