### PR TITLE
Properly format and reference MIT License

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,6 @@
-Copyright 2020 Thence LLC
+MIT License
+
+Copyright (c) 2020 Thence LLC
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 


### PR DESCRIPTION
I notice that the content of the LICENSE is in relation to the MIT License, but the normally expected first line is missing