### PR TITLE
ci: adding url-validator via github actions

### DIFF
--- a/.brokignore
+++ b/.brokignore
@@ -1,0 +1,2 @@
+https://example.com
+https://www.example.com

--- a/.brokignore
+++ b/.brokignore
@@ -10,7 +10,6 @@ https://docs.google.com/document/d/14o1AVg10CBbLlqNqBrCz4HkR
 https://api.segment.io
 https://github.com/LukeCarrier/brain
 https://github.com/dendronhq/seed.services/settings/pages
-
-https://github.com/dendronhq/dendron-site/edit/master/vault/dendron.tutorial.links.md
+https://github.com/dendronhq/dendron-site/edit/
 https://www.slant.co/topics/4962/viewpoints/44/~personal-knowledge-base-apps~dendron
 https://org-dendron-public-assets.s3.amazonaws.com/publish/

--- a/.brokignore
+++ b/.brokignore
@@ -8,7 +8,6 @@ https://john.dendron.wiki
 https://kevinslin.github.io
 https://docs.google.com/document/d/14o1AVg10CBbLlqNqBrCz4HkR
 https://api.segment.io
-https://github.com/LukeCarrier/brain
 https://github.com/dendronhq/seed.services/settings/pages
 https://github.com/dendronhq/dendron-site/edit/
 https://www.slant.co/topics/4962/viewpoints/44/~personal-knowledge-base-apps~dendron

--- a/.brokignore
+++ b/.brokignore
@@ -5,6 +5,7 @@ https://localhost
 http://wiki.dendron.so
 https://wiki.dendron.so
 https://john.dendron.wiki
+https://kevinslin.github.io
 https://docs.google.com/document/d/14o1AVg10CBbLlqNqBrCz4HkR
 https://api.segment.io
 https://github.com/LukeCarrier/brain
@@ -12,3 +13,4 @@ https://github.com/dendronhq/seed.services/settings/pages
 
 https://github.com/dendronhq/dendron-site/edit/master/vault/dendron.tutorial.links.md
 https://www.slant.co/topics/4962/viewpoints/44/~personal-knowledge-base-apps~dendron
+https://org-dendron-public-assets.s3.amazonaws.com/publish/

--- a/.brokignore
+++ b/.brokignore
@@ -1,2 +1,4 @@
 https://example.com
 https://www.example.com
+http://wiki.dendron.so
+https://wiki.dendron.so

--- a/.brokignore
+++ b/.brokignore
@@ -8,7 +8,9 @@ https://john.dendron.wiki
 https://kevinslin.github.io
 https://docs.google.com/document/d/14o1AVg10CBbLlqNqBrCz4HkR
 https://api.segment.io
+https://github.com
 https://github.com/dendronhq/seed.services/settings/pages
 https://github.com/dendronhq/dendron-site/edit/
+https://github.com/dendronhq/dendron-backend/
 https://www.slant.co/topics/4962/viewpoints/44/~personal-knowledge-base-apps~dendron
 https://org-dendron-public-assets.s3.amazonaws.com/publish/

--- a/.brokignore
+++ b/.brokignore
@@ -1,4 +1,8 @@
 https://example.com
 https://www.example.com
+http://localhost
+https://localhost
 http://wiki.dendron.so
 https://wiki.dendron.so
+https://docs.google.com/document/d/14o1AVg10CBbLlqNqBrCz4HkR
+https://api.segment.io

--- a/.brokignore
+++ b/.brokignore
@@ -4,5 +4,11 @@ http://localhost
 https://localhost
 http://wiki.dendron.so
 https://wiki.dendron.so
+https://john.dendron.wiki
 https://docs.google.com/document/d/14o1AVg10CBbLlqNqBrCz4HkR
 https://api.segment.io
+https://github.com/LukeCarrier/brain
+https://github.com/dendronhq/seed.services/settings/pages
+
+https://github.com/dendronhq/dendron-site/edit/master/vault/dendron.tutorial.links.md
+https://www.slant.co/topics/4962/viewpoints/44/~personal-knowledge-base-apps~dendron

--- a/.github/workflows/url-auditor.yml
+++ b/.github/workflows/url-auditor.yml
@@ -36,4 +36,4 @@ jobs:
         dpkg -i brok-1.1.0_x86-64-linux.deb
     - name: Run brok
       run: |
-        brok --ignore $(cat .brokignore) $(find . -type f -name "*.yml") $(find . -type f -name "*.md")
+        brok --ignore $(cat .brokignore) $(find . -type f -name "*.yml") $(find . -type f -name "*.md") > /dev/null

--- a/.github/workflows/url-auditor.yml
+++ b/.github/workflows/url-auditor.yml
@@ -36,4 +36,4 @@ jobs:
         dpkg -i brok-1.1.0_x86-64-linux.deb
     - name: Run brok
       run: |
-        brok --ignore $(cat .brokignore) $(find . -type f -name "*.yml") $(find . -type f -name "*.md") > /dev/null
+        brok --ignore $(cat .brokignore) $(find . -path ./data -prune -type f -name "*.yml") $(find . -type f -name "*.md") > /dev/null

--- a/.github/workflows/url-auditor.yml
+++ b/.github/workflows/url-auditor.yml
@@ -1,0 +1,39 @@
+name: URL validator
+
+on: [push, pull_request]
+
+jobs:
+  Pre-Commit:
+    name: Run brok Against files in repo
+
+    runs-on: ubuntu-latest
+
+    container:
+      image: debian:bullseye-slim
+
+    steps:
+
+    - name: Install System Deps
+      run: |
+        apt-get update
+        apt-get install -y wget libtinfo5
+
+    - uses: actions/checkout@v2
+
+    - name: Get Date
+      id: get-date
+      run: |
+        echo "::set-output name=date::$(/bin/date -u "+%Y%m")"
+      shell: bash
+    - uses: actions/cache@v2
+      with:
+        path: .brokdb
+        key: ${{ hashFiles('.github/workflows/url-auditor.yml') }}-${{ hashFiles('.brokignore') }}-${{ steps.get-date.outputs.date }}
+
+    - name: Install brok
+      run: |
+        wget https://github.com/smallhadroncollider/brok/releases/download/1.1.0/brok-1.1.0_x86-64-linux.deb
+        dpkg -i brok-1.1.0_x86-64-linux.deb
+    - name: Run brok
+      run: |
+        brok --ignore $(cat .brokignore) $(find . -type f -name "*.yml") $(find . -type f -name "*.md")

--- a/vault/dendron.community.showcase.md
+++ b/vault/dendron.community.showcase.md
@@ -2,7 +2,7 @@
 id: 3a82c5ff-7945-46ae-8bf9-3b2275fc6642
 title: Showcase
 desc: ''
-updated: 1630732109385
+updated: 1630790917267
 created: 1600010740851
 ---
 Below are examples of published Dendron vaults
@@ -33,13 +33,6 @@ Below are examples of published Dendron vaults
 - homepage: <https://kevinslin.com/>
 - discord: `@kevins8#0590`
   ![](/assets/images/2020-09-13-08-45-00.png)
-
-### Ed's Page
-
-- homepage: <https://ens100.github.io/>
-- discord: `@edns100#4851`
-
-![](/assets/images/2020-09-13-09-04-36.png)
 
 ### Luke's second brain
 

--- a/vault/dendron.community.showcase.md
+++ b/vault/dendron.community.showcase.md
@@ -2,7 +2,7 @@
 id: 3a82c5ff-7945-46ae-8bf9-3b2275fc6642
 title: Showcase
 desc: ''
-updated: 1614059886015
+updated: 1630732109385
 created: 1600010740851
 ---
 Below are examples of published Dendron vaults
@@ -40,13 +40,6 @@ Below are examples of published Dendron vaults
 - discord: `@edns100#4851`
 
 ![](/assets/images/2020-09-13-09-04-36.png)
-
-### Jack's page
-
-- homepage: <https://imalightbulb.xyz>
-- discord: `@I'm a lightbulb#6986`
-
-![](/assets/images/2020-09-13-09-01-48.png)
 
 ### Luke's second brain
 

--- a/vault/dendron.dev.api.seeds.md
+++ b/vault/dendron.dev.api.seeds.md
@@ -2,7 +2,7 @@
 id: 08a917a9-31f1-434d-bc7f-71dce2b63a27
 title: Seeds
 desc: ''
-updated: 1616949372174
+updated: 1630642378884
 created: 1600376826105
 stub: false
 published: false
@@ -11,7 +11,7 @@ published: false
 
 # DendronSeed
 
-Base class to extend from when creating a new seed. Documentation is still under construction. In the meanwhile, you can use [the code](https://github.com/dendronhq/dendron/blob/master/packages/seeds-core/src/base.ts#L39) as a guide when creating a new seed.
+Base class to extend from when creating a new seed. Documentation is still under construction. In the meanwhile, you can use [the code](https://github.com/dendronhq/dendron/blob/master/packages/seeds-core/src/base.ts) as a guide when creating a new seed.
 
-You can see an example of a seed implementation [here](https://github.com/dendronhq/seeds.aws/blob/master/packages/awsgeek-seed/src/index.ts#L63:L63)
+You can see an example of a seed implementation [here](https://github.com/dendronhq/seeds.aws/blob/master/packages/awsgeek-seed/src/index.ts)
 

--- a/vault/dendron.dev.api.seeds.md
+++ b/vault/dendron.dev.api.seeds.md
@@ -11,7 +11,7 @@ published: false
 
 # DendronSeed
 
-Base class to extend from when creating a new seed. Documentation is still under construction. In the meanwhile, you can use [the code](https://github.com/dendronhq/dendron/blob/master/packages/seeds-core/src/base.ts) as a guide when creating a new seed.
+Base class to extend from when creating a new seed. Documentation is still under construction.
 
 You can see an example of a seed implementation [here](https://github.com/dendronhq/seeds.aws/blob/master/packages/awsgeek-seed/src/index.ts)
 

--- a/vault/dendron.dev.cook.md
+++ b/vault/dendron.dev.cook.md
@@ -2,7 +2,7 @@
 id: a80f36d9-01d0-4c5a-a228-867b093a4913
 title: Cook Book
 desc: ''
-updated: 1630346538390
+updated: 1630796536132
 created: 1599151918645
 stub: false
 ---
@@ -135,8 +135,7 @@ To make this customizable, the following changes need to be made:
 
 When all this is done, we can add tests that the formatting behavior works
 
-- [ ] [engine tests](https://github.com/dendronhq/dendron/blob/master/packages/engine-server/src/__tests__/enginev2.spec.ts#L652:L652)
-- [ ] [plugin test](https://github.com/dendronhq/dendron/blob/master/packages/plugin-core/src/test/suite-integ/RenameNoteV2.test.ts#L157:L157)
+- [ ] [engine tests](https://github.com/dendronhq/dendron/blob/master/packages/engine-test-utils/src/__tests__/engine-server/enginev2.spec.ts)
 
 The above changes are for `Rename`. `Refactor` calls rename in a loop so changing rename should update refactor as well.
 

--- a/vault/dendron.dev.cook.md
+++ b/vault/dendron.dev.cook.md
@@ -125,13 +125,13 @@ These are [rough notes](https://dendron.so/notes/849ee8ee-05a5-47bf-b44d-d7c2571
 
 To make this customizable, the following changes need to be made:
 
-- [ ] update the [DendronConfig type definition](https://github.com/dendronhq/dendron/blob/master/packages/common-all/src/types.ts#L405:L405)
+- [ ] update the [DendronConfig type definition](https://github.com/dendronhq/dendron/blob/master/packages/common-all/src/types/typesv2.ts)
 - [ ] update [config defaults](https://github.com/dendronhq/dendron/blob/master/packages/engine-server/src/config.ts#L42:L42)
 - [ ] pass in formatting options from the [plugin](https://github.com/dendronhq/dendron/blob/master/packages/plugin-core/src/commands/RenameNoteV2a.ts#L137:L137)
 - [ ] accept formatting args in the [server](https://github.com/dendronhq/dendron/blob/master/packages/api-server/src/routes/note.ts#L38:L38)
 - [ ] accept formatting args in the [engine](https://github.com/dendronhq/dendron/blob/master/packages/engine-server/src/enginev2.ts#L249:L249)
-- [ ] accept it when [replacing links](https://github.com/dendronhq/dendron/blob/master/packages/engine-server/src/topics/markdown/utilsv2.ts#L85:L85)
-- [ ] accept it in [remark pipeline](https://github.com/dendronhq/dendron/blob/master/packages/engine-server/src/topics/markdown/utilsv2.ts#L41:L41)
+- [ ] accept it when [replacing links](https://github.com/dendronhq/dendron/blob/master/packages/engine-server/src/markdown/utilsv5.ts)
+- [ ] accept it in [remark pipeline](https://github.com/dendronhq/dendron/blob/master/packages/engine-server/src/markdown/remark/utils.ts)
 
 When all this is done, we can add tests that the formatting behavior works
 

--- a/vault/dendron.dev.errors.md
+++ b/vault/dendron.dev.errors.md
@@ -2,7 +2,7 @@
 id: 2b87ceb3-2a90-4dee-ab8e-980172ecaef1
 title: Errors
 desc: ''
-updated: 1620880732981
+updated: 1630791786886
 created: 1620879891784
 ---
 
@@ -11,7 +11,7 @@ created: 1620879891784
 
 This page describes how we handle errors in Dendron.
 
-Any error that is throw by Dendron should extend from [`DendronError`](https://github.com/dendronhq/dendron/blob/dev-kevin/packages/common-all/src/error.ts#L13:L13). 
+Any error that is throw by Dendron should extend from [`DendronError`](https://github.com/dendronhq/dendron/blob/master/packages/common-all/src/error.ts). 
 
 ## Details
 - If a function can return multiple errors, use `DendronCompositeError` to wrap up multiple errors
@@ -24,7 +24,7 @@ Any error that is throw by Dendron should extend from [`DendronError`](https://g
 
 ### ERROR_STATUS
 
-These match to common errors in Dendron. You can find the full list [here](https://github.com/dendronhq/dendron/blob/dev-kevin/packages/common-all/src/constants.ts#L18)
+These match to common errors in Dendron. You can find the full list [here](https://github.com/dendronhq/dendron/blob/master/packages/common-all/src/constants.ts)
 
 ### ERROR_SEVERITY
 

--- a/vault/dendron.dev.qa.debug.md
+++ b/vault/dendron.dev.qa.debug.md
@@ -2,7 +2,7 @@
 id: yhpcSlIpwsBX2iHjfyutP
 title: Debug
 desc: ''
-updated: 1630441646649
+updated: 1630641796543
 created: 1630441590786
 ---
 
@@ -14,9 +14,9 @@ You can put a breakpoint directly in any code that's part of `plugin-core` and i
 
 ### Git Related Tests
 
-Any tests that involve setting up git should use [GitTestUtils](https://github.com/dendronhq/dendron/blob/dev-kevin/packages/engine-test-utils/src/utils.ts#L22:L22). This will help you create a git workspace with necessary commit history. 
+Any tests that involve setting up git should use [GitTestUtils](https://github.com/dendronhq/dendron/blob/master/packages/engine-test-utils/src/utils/git.ts). This will help you create a git workspace with necessary commit history. 
 
-You can see it being used [here](https://github.com/dendronhq/dendron/blob/dev-kevin/packages/engine-test-utils/src/__tests__/engine-server/workspace.spec.ts#L21:L21).
+You can see it being used [here](https://github.com/dendronhq/dendron/blob/master/packages/engine-test-utils/src/__tests__/engine-server/workspace.spec.ts).
 
 If a tests involve a remote git repository, use `tmpDir` to setup a *local remote*. Use `GitTestUtils` to create a repo and then push an dpull to the local remote.
 

--- a/vault/dendron.dev.qa.md
+++ b/vault/dendron.dev.qa.md
@@ -2,7 +2,7 @@
 id: cb22bd36-d45a-4ffd-a31e-96c4b39cb7fb
 title: Testing
 desc: ''
-updated: 1629905535827
+updated: 1630794229821
 created: 1598654055046
 stub: false
 ---
@@ -72,7 +72,7 @@ describe("foo", function() {
 });
 ```
 
-You can see an example of a test [here](https://github.com/dendronhq/dendron/blob/dev-kevin/packages/plugin-core/src/commands/CopyNoteURL.ts#L1:L1)
+You can see an example of a test [here](https://github.com/dendronhq/dendron/blob/master/packages/plugin-core/src/commands/CopyNoteURL.ts)
 
 Also, consider enabling "Uncaught Exceptions" under "Breakpoints" when running tests. Otherwise, if you forget to `await` a function that returns a promise and that function throws an exception, the test will appear to pass even though an exception was thrown.
 

--- a/vault/dendron.dev.qa.sop.md
+++ b/vault/dendron.dev.qa.sop.md
@@ -2,7 +2,7 @@
 id: BZHowLgEOrWthrWI
 title: QA Sop
 desc: ''
-updated: 1628711286318
+updated: 1630794884027
 created: 1626369413296
 ---
 
@@ -12,5 +12,5 @@ created: 1626369413296
 
 ### Case Specific
 - [ ] if your tests changes an existing snaphot, make sure that snapshots are [[updated|dendron.dev.qa#updating-test-snapshots]]
-- [ ] if you are adding a new language feature (graphically visible in vscode/preview/publishing), make sure that it is included in [test-workspace](https://github.com/dendronhq/dendron/blob/feat/hashtag-tags/test-workspace/dendron.yml#L1:L1). We use this to manually inspect new changes and for auto regression testiing 
+- [ ] if you are adding a new language feature (graphically visible in vscode/preview/publishing), make sure that it is included in [test-workspace](https://github.com/dendronhq/dendron/blob/master/test-workspace/dendron.yml). We use this to manually inspect new changes and for auto regression testiing 
 - [ ] if you are adding telemetry related changes, make sure the [[Telemetry|dendron.ref.telemetry]] docs are updated

--- a/vault/dendron.dev.qa.windows.md
+++ b/vault/dendron.dev.qa.windows.md
@@ -34,7 +34,7 @@ For reference, take a look at a few example PR's below that fix issues similar t
 
 ### Skipping Windows Test (Last Resort)
 
-If a test continues to fail despite trying the methods listed above, the test may be skipped using the following test runner for the plugin: [runTestButSkipForWindows](https://github.com/dendronhq/dendron/blob/chore/windows-ci-hashtags/packages/plugin-core/src/test/testUtilsV3.ts#L405:L405)
+If a test continues to fail despite trying the methods listed above, the test may be skipped using the following test runner for the plugin: [runTestButSkipForWindows](https://github.com/dendronhq/dendron/blob/master/packages/plugin-core/src/test/testUtilsV3.ts)
 
 ## Troubleshooting Windows CI Failures on Github Actions
 

--- a/vault/dendron.dev.setup.md
+++ b/vault/dendron.dev.setup.md
@@ -2,7 +2,7 @@
 id: 64f0e2d5-2c83-43df-9144-40f2c68935aa
 title: Setup Dendron Development Environment
 desc: ''
-updated: 1629773462118
+updated: 1630794166287
 created: 1598651458825
 ---
 
@@ -78,11 +78,11 @@ Also note that many objects (eg. commands, pods, etc), have an instance of the l
 
 Some things to keep in mind:
   - Do not use `console.log` to log data
-  - Raw note objects contain note content which we never want to log. Instead, use [`NoteUtils.toLogObj`](https://github.com/dendronhq/dendron/blob/dev-kevin/packages/common-all/src/dnode.ts#L803:L803) which strips out sensitive fields to the logger. 
+  - Raw note objects contain note content which we never want to log. Instead, use [`NoteUtils.toLogObj`](https://github.com/dendronhq/dendron/blob/master/packages/common-all/src/dnode.ts) which strips out sensitive fields to the logger. 
 
 ## Exceptions
 
-When handling a Dendron specific error, use the [DendronError](https://github.com/dendronhq/dendron/blob/dev-joshi/packages/common-all/src/error.ts#L38:L38) class
+When handling a Dendron specific error, use the [DendronError](https://github.com/dendronhq/dendron/blob/master/packages/common-all/src/error.ts) class
 
 Some things to keep in mind:
   - when returning an error from the server, note that you'll need to convert the error to a plain object using [error2PlainObject](https://github.com/dendronhq/dendron/blob/master/packages/common-all/src/error.ts#L110)

--- a/vault/dendron.dev.style.md
+++ b/vault/dendron.dev.style.md
@@ -17,7 +17,7 @@ We use [eslint](https://eslint.org/) and [prettier](https://prettier.io/) to aut
 
 ## Time
 
-We use [`luxon`](https://moment.github.io/luxon/docs/class/src/datetime.js~DateTime.html) for all time related tasks. This is the successor of [`moment.js`](https://sebastiandedeyne.com/moment-js-thank-you-for-your-service/)
+We use [`luxon`](https://moment.github.io/luxon/api-docs/index.html#datetime) for all time related tasks. This is the successor of [`moment.js`](https://sebastiandedeyne.com/moment-js-thank-you-for-your-service/)
 
 
 ## General

--- a/vault/dendron.guides.cook.md
+++ b/vault/dendron.guides.cook.md
@@ -291,7 +291,7 @@ You can access the site with username: `dendron`, password: `hierarchy`.
 
 #### Setup your github repo
 
-1. Create a new github repo using this [template](https://github.com/dendronhq/dendron-amplify-template/generate).
+1. Create a new github repo using this [template](https://github.com/dendronhq/dendron-amplify-template).
 2. In your Dendron workspace, remove the `docs` directory and clone your newly created repository
     ```bash
     cd {your-workspace}

--- a/vault/dendron.guides.cook.md
+++ b/vault/dendron.guides.cook.md
@@ -2,7 +2,7 @@
 id: 401c5889-20ae-4b3a-8468-269def4b4865
 title: Cookbook
 desc: ""
-updated: 1628124505607
+updated: 1630796678628
 created: 1595952505024
 nav_order: 8.9
 toc: true
@@ -282,8 +282,6 @@ nodemon --watch {path/to/vault} --ext md dendron-cli buildSite --wsRoot {path/to
 -   NOTE: you can combine this with incremental builds to have the best editing experience
 
 ### Publish password protected site using AWS Amplify
-
-You can click [here](https://main.d19svbygngqnpb.amplifyapp.com/) to see a demo of the end result.
 
 You can access the site with username: `dendron`, password: `hierarchy`.
 

--- a/vault/dendron.guides.tips.md
+++ b/vault/dendron.guides.tips.md
@@ -2,7 +2,7 @@
 id: 692fa114-f798-467f-a0b9-3cccc327aa6f
 title: Tips
 desc: ''
-updated: 1620400139991
+updated: 1630795728576
 created: 1595614204291
 ---
 
@@ -132,7 +132,7 @@ gitignore
     },
     "repository": {
       "type": "git",
-      "url": "git+https://github.com/LukeCarrier/brain.git"
+      "url": "git+https://github.com/{{username}}/{{repo}}.git"
     },
     "license": "Creative Commons Attribution 4.0 International",
     "devDependencies": {

--- a/vault/dendron.release.2020-07-25.md
+++ b/vault/dendron.release.2020-07-25.md
@@ -2,7 +2,7 @@
 id: 6aed338c-df05-420d-aa7b-59dfd2214349
 title: Release Notes(version 0.4)
 desc: ''
-updated: 1630729581623
+updated: 1630790746247
 created: 1595984607502
 date: 2020-07-25
 ---
@@ -24,7 +24,7 @@ Dendron has a completely re-done getting started. you can see it by running `> D
 
 ### 🚧 Graph View for Hierarchies ([129bf4e](https://github.com/dendronhq/dendron/commit/129bf4e4e480dfbff66530725c6db8d2321adc28))
 
-- [docs](https://github.com/dendronhq/dendron-template/blob/master/vault/dendron.topic.graph-view.md)
+- [[docs|dendron.topic.graph-view]]
 
 Note that Dendron's graph view lays out your notes according to their hierarchy (vs backlinks).
 

--- a/vault/dendron.release.2020-07-25.md
+++ b/vault/dendron.release.2020-07-25.md
@@ -2,7 +2,7 @@
 id: 6aed338c-df05-420d-aa7b-59dfd2214349
 title: Release Notes(version 0.4)
 desc: ''
-updated: 1609990780194
+updated: 1630729581623
 created: 1595984607502
 date: 2020-07-25
 ---
@@ -36,37 +36,35 @@ Dendron is now compatible with windows
 
 ### Upgrade Settings Command ([c043090](https://github.com/dendronhq/dendron/commit/c0430905d314c6ee870f9bdd45434f53e93a7098))
 
-- [docs](https://github.com/dendronhq/dendron-template/blob/master/vault/dendron.topic.commands.md#upgrade-settings)
-
 Dendron will automatically update your workspace settings during version upgrades to make sure they stay up to date with new features and bundled extensions. If you've modified the settings or want to restore your settings back to their default, you can run this command.
 
 ### Reload Index Command ([236b2ac](https://github.com/dendronhq/dendron/commit/236b2ac70812c4df525ff27479802b6e49e0587f))
 
-- [docs](https://github.com/dendronhq/dendron-template/blob/master/vault/dendron.topic.commands.md#reload-index)
+- [[docs|dendron.topic.commands#reload-index]]
 
-Dendron will re-initialize the index. This is currently necessary if you add new entries to a [schema](https://github.com/dendronhq/dendron-template/blob/master/vault/dendron.topic.schema.md). Otherwise, Dendron will re-index schemas the next time you reload/open your workspace.
+Dendron will re-initialize the index. This is currently necessary if you add new entries to a [[schema|dendron.topic.schema]]. Otherwise, Dendron will re-index schemas the next time you reload/open your workspace.
 
 ### Open Logs Command ([4f223fc](https://github.com/dendronhq/dendron/commit/4f223fc318fe033471252611c8f41d505dca1055))
 
-- [docs](https://github.com/dendronhq/dendron-template/blob/master/vault/dendron.topic.commands.md#open-logs)
+- [[docs|dendron.topic.commands#open-logs]]
 
 A bunch of you have been submitting issues to our issue tracker. To make the process easier, we now have a command to automatically fetch get the logs for when you submit your next issue.
 
 ### Open Link Command ([7f630d1](https://github.com/dendronhq/dendron/commit/7f630d1fb95d5c0d28fc5a83f4cee27bc17d452c))
 
-- [docs](https://github.com/dendronhq/dendron-template/blob/master/vault/dendron.topic.links.md)
+- [[docs|dendron.topic.links]]
 
 Be able to open non-markdown files using native apps (eg. use preview to open pdfs on mac).
 
 ### Journal Notes ([5e1236f](https://github.com/dendronhq/dendron/commit/5e1236fddbf1e0fddf4c27d1a40e9841cc99974f))
 
-- [docs](https://github.com/dendronhq/dendron-template/blob/master/vault/dendron.topic.special-notes.md#journal-note)
+- [[docs|dendron.topic.special-notes#journal-note]]
 
 A journal note is a self contained note that is meant to track something over time. Examples of journals include recording workout sessions, making meeting notes, and keeping a mood journal.
 
 ### Scratch Notes scratch ([71d8433](https://github.com/dendronhq/dendron/commit/71d8433fbd10651ec7fcd13a5f7ee41199a43632))
 
-- [docs](https://github.com/dendronhq/dendron-template/blob/master/vault/dendron.topic.special-notes.md#scratch-note)
+- [[docs|dendron.topic.special-notes#scratch-note]]
 
 A scratch note is a self contained note that is meant to be used as scratchpad. Use it for thoughts or when you want to expand on a bullet point. Scratch notes are created in the `scratch` domain and have the following format: `{domain}.journal.{Y-MM-DD-HH-HHmmss}`.
 
@@ -84,7 +82,7 @@ Use webpack to reduce bundle size and reduce startup speed by factor of 10
 
 ### Remove Extra Frontmatter ([e059346](https://github.com/dendronhq/dendron/commit/e0593467fca94a4d29dc9463721a99e67881cfb3))
 
-- [docs](https://github.com/dendronhq/dendron-template/blob/master/vault/dendron.topic.frontmatter.md)
+- [[docs|dendron.topic.frontmatter]]
 
 Dendron keeps track of metadata to your notes using frontmatter. There were many fields that we wrote out that didn't need to be written out because Dendron gathers that information during its index phase. Those fields are now no longer written out!
 

--- a/vault/dendron.release.2020-08-02.md
+++ b/vault/dendron.release.2020-08-02.md
@@ -2,7 +2,7 @@
 id: e32aa1e2-9780-4183-927e-2f46372050aa
 title: Release Notes(version 0.5)
 desc: ''
-updated: 1630642081569
+updated: 1630728498576
 created: 1596374984386
 date: '2020-08-02'
 ---
@@ -24,7 +24,7 @@ Dendron has a series of built-in commands. They are all prefixed with `Dendron:`
 
 ### Add Doctor Command
 
-([d4fa71c](https://github.com/dendronhq/dendron/commit/d4fa71cd839782587d47a3ba1b0f7e89742e7ffe)) ([docs](https://www.dendron.so/notes/eea2b078-1acc-4071-a14e-18299fc28f47.html#doctor))
+([d4fa71c](https://github.com/dendronhq/dendron/commit/d4fa71cd839782587d47a3ba1b0f7e89742e7ffe)) ([[docs|dendron.topic.commands#doctor]])
 
 This makes sure your workspace is up to date. It will execute the following actions:
 
@@ -37,7 +37,7 @@ This makes sure your workspace is up to date. It will execute the following acti
 
 ### Add ShowHelp Command
 
-([ecf3c68](https://github.com/dendronhq/dendron/commit/ecf3c6822848834d9a00e373d1c59b6628e7f4df))([docs](https://www.dendron.so/notes/eea2b078-1acc-4071-a14e-18299fc28f47.html#show-help))
+([ecf3c68](https://github.com/dendronhq/dendron/commit/ecf3c6822848834d9a00e373d1c59b6628e7f4df))([[docs|dendron.topic.commands#show-help]])
 
 Dendron will open your current browser to the [[quickstart|dendron.tutorial.recap]] page. 
 
@@ -51,7 +51,7 @@ Pods are the mechanisms Dendron uses to import and export notes. Dendron has a d
 
 ### 🚧 Support Publishing Notes
 
-([e063732](https://github.com/dendronhq/dendron/commit/e063732d1ff082dd8520a479926e7ceb1b0893ab)) ([docs](https://www.dendron.so/notes/73d395c9-5041-4d0d-9db7-080d9586136e.html))
+([e063732](https://github.com/dendronhq/dendron/commit/e063732d1ff082dd8520a479926e7ceb1b0893ab)) ([[docs|pkg.dendron-publishing]])
 
 Dendron lets you publish the contents of your vault, either in its entirety or only a subset. Notes are published under the [dendron-jekyll theme](https://github.com/dendronhq/dendron-jekyll). 
 

--- a/vault/dendron.release.2020-08-02.md
+++ b/vault/dendron.release.2020-08-02.md
@@ -2,7 +2,7 @@
 id: e32aa1e2-9780-4183-927e-2f46372050aa
 title: Release Notes(version 0.5)
 desc: ''
-updated: 1623981566779
+updated: 1630642081569
 created: 1596374984386
 date: '2020-08-02'
 ---
@@ -20,7 +20,7 @@ These release notes are summary of the more notable changes, for the full list, 
 
 ## Commands
 
-Dendron has a series of built-in commands. They are all prefixed with `Dendron:` and can be accessed through the [command prompt](https://www.dendron.so/notes/c6fd6bc4-7f75-4cbb-8f34-f7b99bfe2d50.html#command-palette).
+Dendron has a series of built-in commands. They are all prefixed with `Dendron:` and can be accessed through the [[command prompt|dendron.concepts#command-palette]].
 
 ### Add Doctor Command
 
@@ -149,7 +149,7 @@ Bugfixes for this release
 - CI/CD testing ([d6ce68c](https://github.com/dendronhq/dendron/commit/d6ce68c720d7e8c96d7f4bb6ab390c1bd52c5218))
   - Dendron now has continuous integration tests for all pushes. ![](https://travis-ci.com/dendronhq/dendron.svg?branch=master)
   - Tests run on mac, linux and windows which means moving forward, there should be fewer OS (aka Windows) related issues 
-- Update [quickstart docs](http://localhost:4000/notes/e86ac3ab-dbe1-47a1-bcd7-9df0d0490b40.html)  to showcase new features ([aec0fe0](https://github.com/dendronhq/dendron/commit/aec0fe0939239d84f5b7ebd9ebae57a09bcdae43))
+- Update quickstart docs to showcase new features ([aec0fe0](https://github.com/dendronhq/dendron/commit/aec0fe0939239d84f5b7ebd9ebae57a09bcdae43))
 
 ## Next
 

--- a/vault/dendron.release.2020-08-16.md
+++ b/vault/dendron.release.2020-08-16.md
@@ -2,7 +2,7 @@
 id: 075e9806-0367-40a2-8154-2e84d5a020e5
 title: Release Notes(version 0.7)
 desc: ''
-updated: 1609990760541
+updated: 1630793198334
 created: 1596374871110
 date: 2020-08-16
 ---
@@ -85,11 +85,11 @@ Or a range!
 
 ## Pods
 
-### Publish Multiple Hierarchies within a Vault ([docs](https://www.dendron.so/notes/73d395c9-5041-4d0d-9db7-080d9586136e.html#selective-publication))
+### Publish Multiple Hierarchies within a Vault ([[docs|dendron.topic.publishing.selective-publication]])
 
 You can now publish 0, one, or N number of hierarchies within a vault. We're working on negative and complex numbers of hierarchies for future releases.  
 
-### Ability to not Publish Select Lines ([docs](https://www.dendron.so/notes/73d395c9-5041-4d0d-9db7-080d9586136e.html#exclude-line-from-publication))
+### Ability to not Publish Select Lines ([[docs|dendron.topic.publishing.selective-publication]])
 
 Unlike what Mark Zuckerberg might want you to believe, people weren't meant to share EVERYTHING with EVERYONE. Use this to keep private lines private!
 

--- a/vault/dendron.release.2020-08-23.md
+++ b/vault/dendron.release.2020-08-23.md
@@ -2,7 +2,7 @@
 id: 075e9806-0367-40a2-8154-2e84d5a1110
 title: Release Notes(version 0.8)
 desc: ''
-updated: 1609990753899
+updated: 1630791648807
 created: 1596374871110
 date: 2020-08-23
 ---
@@ -46,13 +46,13 @@ You can create a daily journal using `> Dendron: Create Daily Journal Note` or `
 
 ## Pods
 
-### Support different defaults on a per hierarchy basis when publishing ([docs](http://dendron.so/notes/73d395c9-5041-4d0d-9db7-080d9586136e.html#config))
+### Support different defaults on a per hierarchy basis when publishing ([[docs|dendron.topic.publishing.selective-publication]])
 
 You can now set different publishing defaults for each hierarchy (as well as general defaults for your entire vault.)
 
 As an example, below is the config for [my website](https://kevinslin.com). It publishes everything under the `home` and `blog` hierarchies but will only publish notes under `books` if `published: true` is set on the frontmatter. 
 
-- dendron.yml
+- `dendron.yml`
 
 ```yml
 site:
@@ -63,7 +63,7 @@ config:
     publishByDefault: false
 ```
 
-### Implement new website config syntax ([docs](http://dendron.so/notes/73d395c9-5041-4d0d-9db7-080d9586136e.html#properties))
+### Implement new website config syntax ([[docs|dendron.topic.publishing.selective-publication]])
 
 New config syntax unifies a bunch of different configuration options and renames others to more sensible names.
 
@@ -119,7 +119,7 @@ foo.bar # match
 foo.bar.one #match
 ```
 
-### Support match by pattern ([docs](http://dendron.so/notes/c5e5adde-5459-409b-b34d-a0d75cbb1052.html#pattern))
+### Support match by pattern ([[docs|dendron.topic.schema#pattern]])
 
 You can now explicitly specify a glob pattern for any level of your schema. If not set, defaults to the schema `id`.
 

--- a/vault/dendron.release.2020-08-30.md
+++ b/vault/dendron.release.2020-08-30.md
@@ -2,7 +2,7 @@
 id: 1a79e2a1-c906-4ed4-a528-15bd34c4e649
 title: Release Notes(version 0.9)
 desc: ''
-updated: 1609990746697
+updated: 1630640295583
 created: 1596374871110
 date: 2020-08-30
 ---
@@ -26,9 +26,9 @@ These release notes are summary of the more notable changes, for the full list, 
 
 ## Hierarchies
 
-### Add Go Up Hierarchy command ([docs](http://localhost:4000/notes/eea2b078-1acc-4071-a14e-18299fc28f47.html#go-up-hierarchy))
+### Add Go Up Hierarchy command
 
-Go up to the closest non-stub parent of the currently open note.
+Go up to the closest non-stub parent of the currently open note. ([[docs|dendron.topic.commands#go-up]])
 
 ![](https://foundation-prod-assetspublic53c57cce-8cpvgjldwysl.s3-us-west-2.amazonaws.com/assets/images/hierarchy.go-up.gif)
 

--- a/vault/dendron.release.2020-09-06.md
+++ b/vault/dendron.release.2020-09-06.md
@@ -2,13 +2,13 @@
 id: 08b2e6ea-bd3e-4f4b-b2b9-676a7b743a65
 title: Release Notes(version 0.10)
 desc: ''
-updated: 1609990740754
+updated: 1630794040065
 created: 1596374871110
 date: '2020-09-06'
 ---
 Dendron turns 0.10 today 🌲. To mark this milestone, the pre-amble for this release will be a tad longer (and more sentimental) than usual. 
 
-This week's release focuses on publication and exports. Dendron sites now come with [one click collaboration support](https://www.dendron.so/notes/73d395c9-5041-4d0d-9db7-080d9586136e.html#edit-on-github), [note references](https://www.dendron.so/notes/73d395c9-5041-4d0d-9db7-080d9586136e.html#note-references), and [hierarchy hints](https://www.dendron.so/notes/73d395c9-5041-4d0d-9db7-080d9586136e.html#nav-based-hierarchy-hints). If publishing online isn't your jam, you'll be happy to know that you can now [export your notes](https://www.dendron.so/notes/66727a39-d0a7-449b-a10d-f6c438185d7f.html#json-pod) to any format you desire (as long as that format is JSON 😅 - more formats coming soon).
+This week's release focuses on publication and exports. Dendron sites now come with [[one click collaboration support|dendron.topic.publishing.features#edit-on-github]], [[note references|dendron.topic.publishing.features#note-references]], and [[hierarchy hints|dendron.topic.publishing.features#nav-based-hierarchy-hints]]. If publishing online isn't your jam, you'll be happy to know that you can now [export your notes](https://www.dendron.so/notes/66727a39-d0a7-449b-a10d-f6c438185d7f.html#json-pod) to any format you desire (as long as that format is JSON 😅 - more formats coming soon).
 
 It's now been almost two months since Dendron first went into preview. Since launch, we've passed over a thousand downloads and closed over [100 issues](https://github.com/dendronhq/dendron/issues?q=is%3Aissue+is%3Aclosed) worth of features, enhancements, and bug fixes. 
 

--- a/vault/dendron.release.2020-09-13.md
+++ b/vault/dendron.release.2020-09-13.md
@@ -2,7 +2,7 @@
 id: 50071eda-fc46-4aca-ba6c-9d53db00d068
 title: Release Notes(version 0.11)
 desc: ''
-updated: 1616949890224
+updated: 1630731585206
 created: 1596374871110
 date: '2020-09-13'
 ---
@@ -137,7 +137,7 @@ Last and most of all, a big **thanks** to the following gardeners that brought u
   - suggest [better block refs](https://github.com/dendronhq/dendron/issues/174)
   - suggest block refs autocomplete 
 
-- [Mr. Lightbulb](https://github.com/JackQAQ-byte)
+- `Mr. Lightbulb`
   - [latex doesn't render when publishing](https://github.com/dendronhq/dendron/issues/195)
 
 - [Tom](https://github.com/peanutputter)

--- a/vault/dendron.release.2020-09-20.md
+++ b/vault/dendron.release.2020-09-20.md
@@ -2,7 +2,7 @@
 id: 8e59e25f-808c-42f1-a82a-e9ce4fd8edd8
 title: Release Notes(version 0.12)
 desc: ''
-updated: 1616949957976
+updated: 1630733055585
 created: 1596374871110
 date: '2020-09-20'
 ---
@@ -113,7 +113,7 @@ Last and most of all, a big **thanks** to the following gardeners that brought u
 - [Daria Vasyukova](https://github.com/gereleth)
   - bug with copy note url
 
-- [Jack](https://github.com/JackQAQ-byte)
+- `Jack`
   - issue with images on published sites
 
 - [Tom](https://github.com/peanutputter)

--- a/vault/dendron.release.2020-11-01.md
+++ b/vault/dendron.release.2020-11-01.md
@@ -2,7 +2,7 @@
 id: 98ad9b6b-53f3-4883-939e-e14055f2cac7
 title: Release Notes(version 0.14)
 desc: ''
-updated: 1616950002664
+updated: 1630640681189
 created: 1604241475533
 ---
 Dendron 0.14 is here 🌱
@@ -26,8 +26,8 @@ As part of getting out of preview, we are launching on [Product Hunt](https://ww
 - complete [[server migration|dendron.roadmap.project.n.2020.server-migration]] for all users
 - create [[snapshots|dendron.topic.capabilities.snapshot]] of your vault and restore them back to a specific point in time
 - introduce [Environmentalist Plans](https://accounts.dendron.so/account/subscribe) for folks that want to support Dendron financially
-- add [publishing](https://dendron.so/notes/66727a39-d0a7-449b-a10d-f6c438185d7f.html#publish) capability to pods (with ability to publish to json and regular markdown)
-- support creating generated [table of contents](https://dendron.so/notes/ffa6a4ba-5eda-48c7-add5-8e2333ba27b4.html#toc) when publishing
+- add [[publishing|dendron.topic.pod#publish]] capability to pods (with ability to publish to json and regular markdown)
+- support creating generated table of contents when publishing
 - realtime schema validation when saving
 - numerous enhancements 
 - numerous bug fixes 
@@ -60,7 +60,7 @@ As part of getting out of preview, we are launching on [Product Hunt](https://ww
 ### House Keeping
 
 - `dendron.noServerMode` setting has been removed
-- Dendron docs has been re-organized to be less overwhelming (if you have an links bookmarked, they will still all work because of Dendron's [permanent links](https://dendron.so/notes/5fcb8564-7209-4a80-9bb8-025bc8eb489b.html#permanent-ids))
+- Dendron docs has been re-organized to be less overwhelming (if you have any links bookmarked, they will still all work because of Dendron's [[permanent links|dendron.topic.publishing#permanent-ids]]
 
 ### Upcoming
 

--- a/vault/dendron.release.2020-11-08.md
+++ b/vault/dendron.release.2020-11-08.md
@@ -2,7 +2,7 @@
 id: 63ea2e72-4eba-406c-9f4c-7300fa0b8935
 title: Release Notes(version 0.15)
 desc: ''
-updated: 1616950012440
+updated: 1630732490664
 created: 1604882865662
 ---
 Dendron 0.15 is here 🌱
@@ -41,4 +41,4 @@ I'm thrilled to announce our latest **Dendrologist**! Meet Luke (@lukecarrier#20
 - [seedublancaster](https://github.com/seedublancaster)
   - [fix typos](https://github.com/dendronhq/dendron/pull/323)
 - [tfer](https://github.com/tfer)
-  - [update docs on stub](https://github.com/dendronhq/dendron-template/pull/33/files)
+  - update docs on stub

--- a/vault/dendron.release.2020-11-15.md
+++ b/vault/dendron.release.2020-11-15.md
@@ -42,7 +42,7 @@ Last and most of all, a big **thanks** to the following gardeners that brought u
 - [Chris Pickett](https://github.com/bunchesofdonald) 
   - [fix typos in initial vault notes](https://github.com/dendronhq/dendron/pull/335)
 - [Jan Reitz](https://github.com/janreitz) 
-  - [fix yml block in docs](https://github.com/dendronhq/dendron-template/pull/36)
+  - [fix yml block in docs](https://github.com/dendronhq/dendron-site/pull/36)
 - [Konrad Jamrozik](https://github.com/konrad-jamrozik)
   - [bad schema in initial vault notes](https://github.com/dendronhq/dendron/issues/342)
 - [Danny Tran](https://github.com/nabdtran)

--- a/vault/dendron.release.2020-11-22.md
+++ b/vault/dendron.release.2020-11-22.md
@@ -2,7 +2,7 @@
 id: f09162ec-6b20-4b53-bd5c-68aaa4698ed8
 title: Release Notes(version 0.17)
 desc: ''
-updated: 1616950026025
+updated: 1630794120340
 created: 1606074212157
 ---
 Dendron 0.17 has sprouted 🌱
@@ -57,9 +57,9 @@ Last and most of all, a big **thanks** to the following gardeners that brought u
   - [missing welcome note](https://github.com/dendronhq/dendron/issues/361)
 - [Gabriel Horner](https://github.com/cldwalker)
   - [update multi-vault docs](https://github.com/dendronhq/dendron-site/pull/39)
-- [Oli Crask](https://github.com/OxygenLithium)     
+- Oli Crask (`OxygenLithium`)    
   - [Stale notes in tree view](https://github.com/dendronhq/dendron/issues/367)
 - [John Young](https://github.com/iterating)
   - [Don't override minimap preferences](https://github.com/dendronhq/dendron/issues/366)
-- [Tim Condit](https://github.com/tcondit)
+- Tim Condit (`tcondit`)
   - [Fix typos](https://github.com/dendronhq/dendron-site/pull/40)

--- a/vault/dendron.release.2021-01-11.md
+++ b/vault/dendron.release.2021-01-11.md
@@ -17,7 +17,7 @@ Dendron 0.24 has sprouted :seedling:
 - bugs and performance related changes
 
 ### Breaking Changes
-- update date format for journal and scratch notes to use [Luxon style formatting](https://moment.github.io/luxon/docs/manual/formatting.html) ([[docs|dendron.topic.config.vscode-config#dendrondefaultjournaldateformat]])
+- update date format for journal and scratch notes to use [Luxon style formatting](https://moment.github.io/luxon/#/formatting) ([[docs|dendron.topic.config.vscode-config#dendrondefaultjournaldateformat]])
   - this affects you if you updated `dendron.default*DateFormat` to something other than the default 
   - we made this change because [moment.js](https://momentjs.com/docs/#/-project-status/), our original date library, is now a legacy project and won't be receiving any new updates
 

--- a/vault/dendron.release.2021-03-22.md
+++ b/vault/dendron.release.2021-03-22.md
@@ -2,7 +2,7 @@
 id: 2d59d6d0-5752-4de6-9027-f6bf9ab63aca
 title: Release Notes (version 0.34)
 desc: ''
-updated: 1617044418611
+updated: 1630791725187
 created: 1616447140240
 ---
 
@@ -38,8 +38,7 @@ You can see an overview of all roles [[here|dendron.community.roles]]
   - update dendron action instructions
 - [Ding](https://github.com/Ding-Fan)
   - launch dendron with most recent vault
-- Tristan Williams @Tristan401#5376  `+planter`
-  - [published dendron site](https://tristan401-2000.github.io/tristan-working-notes-dendron/)
+- [Tristan Williams](https://github.com/Tristan401-2000) @Tristan401#5376  `+planter`
 - [Waldir Pimenta](https://github.com/waldyrious)
   - fix typo
 

--- a/vault/dendron.release.2021-03-29.md
+++ b/vault/dendron.release.2021-03-29.md
@@ -2,7 +2,7 @@
 id: e71bcee0-2e97-49bd-ab5b-634df8903132
 title: Release Notes (version 0.35)
 desc: ''
-updated: 1617644797532
+updated: 1630794855895
 created: 1617039442351
 ---
 
@@ -22,7 +22,7 @@ Old style note references  are formally deprecated and will be removed in future
 A big **thanks** to the following gardeners that brought up issues, contributions, and fixes to this release :man_farmer: :woman_farmer: 
 You can see an overview of all roles [[here|dendron.community.roles]]
 
-- [Vivek Raja](https://github.com/vivkr) `+bugcatcher`
+- Vivek Raja (`vivkr`) `+bugcatcher`
   - Lookup hangs on non-dendron workspace
   - plugin tries to index files outside of dendron workspace
 - [Nbartzokas](https://github.com/nbartzokas)

--- a/vault/dendron.release.2021-05-10.md
+++ b/vault/dendron.release.2021-05-10.md
@@ -2,7 +2,7 @@
 id: 6d77fa3b-f0f1-4fb5-bac1-14389d6efeb5
 title: Release Notes (version 0.41)
 desc: ''
-updated: 1620669972884
+updated: 1630729820688
 created: 1620668738966
 ---
 
@@ -35,7 +35,7 @@ You can see an overview of all roles [[here|dendron.community.roles]]
 - [kalyan02](https://github.com/kalyan02) @pogo#4810
   - `+horticulturalist`
   - create script to help manage unfinished tasks: https://github.com/kalyan02/dendronutils
-- [shorty](https://github.com/shorty25h0r7) @short2links#2229
+- `shorty` @short2links#2229
   - `+bugcatcher`
   - Some Chars Converted To Hex Representation after refactor
 - [Luke Sernau](https://github.com/lsernau)

--- a/vault/dendron.release.changelog.0-2-x.md
+++ b/vault/dendron.release.changelog.0-2-x.md
@@ -234,7 +234,7 @@ You can now publish and build your notes without going to the command line ([[do
 
 ### House Cleaning
 
--   update on date format for journal and scratch notes to use [Luxon style formatting](https://moment.github.io/luxon/docs/manual/formatting.html)
+-   update on date format for journal and scratch notes to use [Luxon style formatting](https://moment.github.io/luxon/#/formatting)
 
 ## 0.23.1
 
@@ -438,7 +438,7 @@ There are additional optimizations still on the table that will further drive do
 
 #### Migration
 
-All values that used to be written into `_config.yml` will now be moved into `dendron.yml`. You can see the currently supported configuration values here: `https://github.com/dendronhq/dendron/blob/master/packages/common-all/src/types.ts#L71:L71`
+All values that used to be written into `_config.yml` will now be moved into `dendron.yml`. You can see the currently supported configuration values here: `https://github.com/dendronhq/dendron/blob/master/packages/common-all/src/types/typesv2.ts`
 
 If you currently have a Jekyll based Dendron page, note that the following settings have changed:
 

--- a/vault/dendron.rfc.10-blocks.md
+++ b/vault/dendron.rfc.10-blocks.md
@@ -17,7 +17,7 @@ Block references let you link or embed blocks of text into different parts of yo
 
 This section describes existing work that has been done on this topic. 
 
-- [roam block references](https://www.roamtips.com/home/what-is-block-roam-research)
+- [roam block references](https://roamresearch.com/)
 - [obsidian links to blocks](https://help.obsidian.md/How+to/Link+to+blocks)
 
 ## Proposal

--- a/vault/dendron.rfc.2-managed-publishing.md
+++ b/vault/dendron.rfc.2-managed-publishing.md
@@ -8,7 +8,7 @@ created: 1611853430165
 
 ## Goal
 
-Make it easy for everyone to publish a [digital garden](https://www.kevinslin.com/notes/30a9ec3e-d58f-44ce-8d7c-535f122f7d0b.html)
+Make it easy for everyone to publish a [digital garden](https://www.kevinslin.com/)
 
 ## Tenants
 - publishing should be accessible to everyone

--- a/vault/dendron.rfc.7-graph-rework.design.md
+++ b/vault/dendron.rfc.7-graph-rework.design.md
@@ -62,7 +62,7 @@ Basic keyboard navigation will be implemented for the new graph view. This will 
 
 ##### Other Notes
 
-Making a graph truly accessible is a difficult task. Most visualization libraries (including those researched) say virtually nothing about accessibility. While a tradeoff of creating a rich graph may be accessibility, some of the [canvas accessibility ideas shared by Mozilla](https://developer.mozilla.org/en-US/docs/Web/API/Canvas_API/Tutorial/Hit_regions_and_accessibility) creating possibilities for creating a more accessible graph display.
+Making a graph truly accessible is a difficult task. Most visualization libraries (including those researched) say virtually nothing about accessibility. While a tradeoff of creating a rich graph may be accessibility, some of the [canvas accessibility ideas shared by Mozilla](https://web.archive.org/web/20210512193630/https://developer.mozilla.org/en-US/docs/Web/API/Canvas_API/Tutorial/Hit_regions_and_accessibility) creating possibilities for creating a more accessible graph display.
 
 ---
 

--- a/vault/dendron.rfc.9-note-lifecycle-hooks.md
+++ b/vault/dendron.rfc.9-note-lifecycle-hooks.md
@@ -2,7 +2,7 @@
 id: d2f8fe67-36c7-4600-b745-c22bdcb5b2cf
 title: 9 Note Lifecycle Hooks
 desc: ''
-updated: 1620426190118
+updated: 1630731523440
 created: 1619706504483
 ---
 
@@ -34,7 +34,7 @@ We currently have limited ways of programmatically updating a note while editing
 1. Plugins should have the following format
     ```js
     /**
-     @params note: Object with following propertieshttps://github.com/dendronhq/dendron/blob/dev-kevin/packages/common-all/src/typesv2.ts#L135:L153
+     @params note: Object with following properties https://github.com/dendronhq/dendron/blob/master/packages/common-all/src/types/typesv2.ts
      @params execa: instance of https://github.com/sindresorhus/execa#execacommandcommand-options
      */
     module.exports = async function({note, execa}) {

--- a/vault/dendron.rfc.md
+++ b/vault/dendron.rfc.md
@@ -24,7 +24,7 @@ future state of the system and to discover projects for contribution.
 | ✅ done                | [1 - Native Preview Experience](https://wiki.dendron.so/notes/17c61d62-f92e-4002-b8fe-9c05686e4bf9.html) | [@kevin](https://github.com/kevinslin)           |
 | 1️⃣ phase one done    | [11 - Better Tree View](https://wiki.dendron.so/notes/ba8cf4c5-6254-4eca-8072-8001ca5afda7.html)         | [@kevin](https://github.com/kevinslin)           |
 | 1️⃣ phase one done    | [14 - Seed Registry](https://wiki.dendron.so/notes/4039fc46-06b2-4f83-b817-fc490bafbcb3.html)            | [@kevin](https://github.com/kevinslin)           |
-| 1️⃣ phase one done    | [18 - Add Note Index](https://wiki.dendron.so/notes/6TOh3VApIUfap7c3.html)                               | [@hikchoi](https://github.com/cerebrarium)       |
+| 1️⃣ phase one done    | [18 - Add Note Index](https://wiki.dendron.so/notes/6TOh3VApIUfap7c3.html)                               | [@hikchoi](https://github.com/hikchoi)       |
 | 1️⃣ phase one done    | [9 - Note Lifecycle Plugins](https://wiki.dendron.so/notes/d2f8fe67-36c7-4600-b745-c22bdcb5b2cf.html)    | [@kevin](https://github.com/kevinslin)           |
 | 1️⃣ phase one done    | [2 - Managed Publishing](https://wiki.dendron.so/notes/ae4a0c98-e2ea-47e0-8a20-016eba3424be.html)        | [@kevin](https://github.com/kevinslin)           |
 | 👷 implementing       | [16 - Better Tags](https://wiki.dendron.so/notes/NT1cFX6DRkTnzcWwduj2I.html)                             | [@SeriousBug](https://github.com/SeriousBug)     |

--- a/vault/dendron.topic.config.dendron.md
+++ b/vault/dendron.topic.config.dendron.md
@@ -164,7 +164,7 @@ name used for journal notes
 - type: string
 - default: y.MM.dd
 
-Date format used for journal notes. Use [luxon style formatting](https://moment.github.io/luxon/docs/manual/formatting.html)
+Date format used for journal notes. Use [luxon style formatting](https://moment.github.io/luxon/#/formattingl)
 
 ### addBehavior
 - type: string

--- a/vault/dendron.topic.config.vscode-config.md
+++ b/vault/dendron.topic.config.vscode-config.md
@@ -2,7 +2,7 @@
 id: 19a0ea9d-7292-4a68-bc6f-ffd462a54bc5
 title: VSCode Config
 desc: ''
-updated: 1624071484895
+updated: 1630641596187
 created: 1619541378119
 ---
 
@@ -50,7 +50,7 @@ name used for journal notes
 - type: string
 - default: y.MM.dd
 
-Date format used for journal notes. Use [luxon style formatting](https://moment.github.io/luxon/docs/manual/formatting.html)
+Date format used for journal notes. Use [luxon style formatting][luxon-style-formatting].
 
 ## dendron.defaultJournalAddBehavior
 - type: string
@@ -64,7 +64,7 @@ strategy for adding new journal notes
 - type: string
 - default: scratch
 
-Name used for scratch notes. Date format used for scratch notes. Use [luxon style formatting](https://moment.github.io/luxon/docs/manual/formatting.html)
+Name used for scratch notes. Date format used for scratch notes. Use [luxon style formatting][luxon-style-formatting].
 
 ## dendron.defaultScratchDateFormat
 - type: string
@@ -83,7 +83,7 @@ strategy for adding new scratch notes
 ## dendron.defaultTimestampDecorationFormat: 
 - default: DATETIME_MED
 - type: string
-- values (see description of values [here](https://moment.github.io/luxon/docs/manual/formatting.html)) 
+- values (see description of values in [luxon style formatting][luxon-style-formatting]) 
     * DATETIME_FULL
     * DATETIME_FULL_WITH_SECONDS
     * DATETIME_HUGE
@@ -160,3 +160,4 @@ LSP log level
 
 port for server. If not set, will be randomly generated at startup.
 
+[luxon-style-formatting]: https://moment.github.io/luxon/#/formatting

--- a/vault/dendron.topic.hooks.examples.md
+++ b/vault/dendron.topic.hooks.examples.md
@@ -2,7 +2,7 @@
 id: 61055b5f-6216-4fd3-b9a1-82f79017b59e
 title: Examples
 desc: ''
-updated: 1620495882937
+updated: 1630729969933
 created: 1620495882937
 ---
 
@@ -25,7 +25,7 @@ hooks:
 ```js
 const path = require("path");
 /**
- @params note: Object with following properties https://github.com/dendronhq/dendron/blob/dev-kevin/packages/common-all/src/typesv2.ts#L135:L153
+ @params note: Object with following properties https://github.com/dendronhq/dendron/blob/master/packages/common-all/src/types/typesv2.ts
  @params execa: instance of [execa](https://github.com/sindresorhus/execa#execacommandcommand-options)
  @params: _: instance of [lodash](https://lodash.com/docs)
  */

--- a/vault/dendron.topic.hooks.quickstart.md
+++ b/vault/dendron.topic.hooks.quickstart.md
@@ -20,7 +20,7 @@ This should lead to a page like the following:
 ```js
 /**
  @params wsRoot: string, root of your current workspace
- @params note: Object with following properties https://github.com/dendronhq/dendron/blob/dev-kevin/packages/common-all/src/typesv2.ts#L135:L153
+ @params note: Object with following properties https://github.com/dendronhq/dendron/blob/master/packages/common-all/src/types/typesv2.ts
  @params NoteUtils: utilities for working with notes. [code](https://github.com/dendronhq/dendron/blob/master/packages/common-all/src/dnode.ts#L307:L307)
  @params execa: instance of [execa](https://github.com/sindresorhus/execa#execacommandcommand-options)
  @params _: instance of [lodash](https://lodash.com/docs)

--- a/vault/dendron.topic.pod.dev.md
+++ b/vault/dendron.topic.pod.dev.md
@@ -2,7 +2,7 @@
 id: 5de219e6-d9b9-4abf-9367-998109cd57cd
 title: Developing a Pod
 desc: ''
-updated: 1622045743569
+updated: 1630795273532
 created: 1614201272488
 ---
 ## Summary
@@ -76,9 +76,6 @@ module.exports = {
    - since I was running this in a new Dendron vault, I got the following output.
    - you can change the value of the fname config to an existing note's file name to run it against that note.
 
-```markdown
-Hello World
-
 ## The Trail 🥾
 
 Here are the basics of Dendron so you can get started growing your knowledge base.
@@ -90,7 +87,7 @@ Here are the basics of Dendron so you can get started growing your knowledge bas
 - [ ] Use a [snippet](https://www.dendron.so/notes/9eca1992-7540-4d9d-97fb-328b27748b2c.html) for quick note templates
 - [ ] Insert an [image](https://www.dendron.so/notes/a91fd8da-6895-49fe-8164-a17acd8d9a17.html)
 - [ ] Create some [links](https://www.dendron.so/notes/3472226a-ff3c-432d-bf5d-10926f39f6c2.html)
-- [ ] [Publish](https://www.dendron.so/notes/73d395c9-5041-4d0d-9db7-080d9586136e.html) your vault
+- [ ] [[Publish|dendron.topic.publishing.selective-publication]] your vault
 - [ ] Join us on [discord](https://discord.com/invite/6j85zNX) and discuss all things knowledge management with your fellow trail blazers.
 - [ ] For more information, see Dendron's basic [concepts](https://www.dendron.so/notes/c6fd6bc4-7f75-4cbb-8f34-f7b99bfe2d50.html)
 ```

--- a/vault/dendron.topic.publishing.blogging.md
+++ b/vault/dendron.topic.publishing.blogging.md
@@ -30,7 +30,7 @@ blog.thoughts.2021-02-03-bar.md
 ```
 
 ### Using Journal Notes
-You can also designate a journal hierarchy as a collection. The following frontmatter is responsible for the page [here](https://www.kevinslin.com/notes/eda0b03c-270c-4c49-9080-46bd8eb55a1e.html)
+You can also designate a journal hierarchy as a collection. The following frontmatter is responsible for the page [here](https://www.kevinslin.com/notes/b9bc4aa1-4369-446d-91a9-13d4f2a4b8e5.html)
 
 ```yml
 has_collection: true

--- a/vault/dendron.topic.publishing.configuration.md
+++ b/vault/dendron.topic.publishing.configuration.md
@@ -38,7 +38,7 @@ site:
 
 Prefix for assets. 
 
-- NOTE: By default, assets are served from the root. If you are publishing to github pages and followed the instructions [here](https://pages.github.com/) by creating a repo named `{username}.github.io`, then no further action is needed. This is because github will make your site available at `https://{username}.github.io`. If you created a custom repo, you will need to set the prefix to the name of your repo because github will make your site available at `https://username.github.io/{your-repo-name/}`
+- NOTE: By default, assets are served from the root. If you are publishing to github pages and followed the instructions [here](https://pages.github.com/) by creating a repo named `{username}.github.io`, then no further action is needed. This is because github will make your site available at `https://{username}.github.io`. If you created a custom repo, you will need to set the prefix to the name of your repo because github will make your site available at `https://{username}.github.io/{your-repo-name/}`
 
 ### copyAssets
 

--- a/vault/dendron.topic.publishing.migration.md
+++ b/vault/dendron.topic.publishing.migration.md
@@ -2,10 +2,10 @@
 id: fd26b3ef-7978-41c9-8f45-4c4f8414951d
 title: Migration
 desc: ''
-updated: 1609529113068
+updated: 1630794922064
 created: 1608528487798
 ---
-All values that used to be written into `_config.yml` will now be moved into `dendron.yml`. You can see the currently supported configuration values here: `https://github.com/dendronhq/dendron/blob/master/packages/common-all/src/types.ts#L71:L71`
+All values that used to be written into `_config.yml` will now be moved into `dendron.yml`. You can see the currently supported configuration values here: `https://github.com/dendronhq/dendron/blob/master/packages/common-all/src/types/typesv2.ts`
 
 If you currently have a Jekyll based Dendron page, note that the following settings have changed:
 

--- a/vault/dendron.topic.special-notes.md
+++ b/vault/dendron.topic.special-notes.md
@@ -30,7 +30,7 @@ To create a journal note, trigger a lookup and then click on the calendar icon.
 
 By default, Dendron will create the journal note with the following hierarchy `{domain}.journal.{y.MM.dd}`. `{domain}` is the **domain** of the current active note when you execute `New Journal Note`.
 
-A reference for date formatting tokens can be found [here](https://moment.github.io/luxon/docs/manual/formatting.html)
+A reference for date formatting tokens can be found [here](https://moment.github.io/luxon/#/formatting)
 
 ## Scratch Note
 

--- a/vault/dendron.workflows.cache.md
+++ b/vault/dendron.workflows.cache.md
@@ -21,7 +21,7 @@ Dendron is ideally suited for this knowledge-as-a-cache use case.
 
 ## Example
 
-You can see a public example of what this might look like on [Kevin's project reference hierarchy](https://www.kevinslin.com/notes/f46d3d6c-9704-4ddc-ad7d-69612d214905.html). He keeps public reference notes on projects he's used. 
+You can see a public example of what this might look like on [Kevin's project reference hierarchy](https://www.kevinslin.com/notes/3dd58f62-fee5-4f93-b9f1-b0f0f59a9b64.html). He keeps public reference notes on projects he's used. 
 
 Some things to note: 
 

--- a/vault/pkg.common-all.dev.md
+++ b/vault/pkg.common-all.dev.md
@@ -3,7 +3,7 @@ id: 3c80629b-4048-48f0-bdfd-352645bda2ec
 title: Dev
 desc: |
   Development related
-updated: 1628623087376
+updated: 1630794193403
 created: 1622079130106
 ---
 
@@ -29,7 +29,7 @@ In VSCode, you can use the "Goto symbol in workspace" command and type the funct
 
 ### Adding a new property to Dendron Config
 
-Dendron configuration is managed by [DendronConfig](https://github.com/dendronhq/dendron/blob/dev-kevin/packages/common-all/src/types/workspace.ts#L65:L65).
+Dendron configuration is managed by [DendronConfig](https://github.com/dendronhq/dendron/blob/master/packages/common-all/src/types/workspace.ts).
 
 Whenever you add a new entry with a default, make sure to do the following as well.
 - [ ] update `Extension.test.ts` (we have a test that checks for default config values that will break)

--- a/vault/pkg.dendron-engine.cook.md
+++ b/vault/pkg.dendron-engine.cook.md
@@ -72,7 +72,7 @@ if (!engine) {
 
 ### Querying notes by ID
 
-- [type definitions](https://github.com/dendronhq/dendron/blob/master/packages/common-all/src/typesv2.ts#L362:L362)
+- [type definitions](https://github.com/dendronhq/dendron/blob/master/packages/common-all/src/types/typesv2.ts)
 
 ```ts
 
@@ -121,7 +121,7 @@ See [[Initialization|pkg.dendron-engine.arch#initialization]] to see the differe
 When you add a new API to the engine, it needs to be added in both the types and the implementations of the engine:
 
 - types:
-   - [DEngine](https://github.com/dendronhq/dendron/blob/dev/packages/common-all/src/types/typesv2.ts#L353:L353)
+   - [DEngine](https://github.com/dendronhq/dendron/blob/master/packages/common-all/src/types/typesv2.ts)
 
 - implementation:
    - [Store](https://github.com/dendronhq/dendron/blob/dev/packages/engine-server/src/drivers/file/storev2.ts#L1:L1): engine methods usually operate on the storage layer (eg. write to disk, read from disk) and so store methods often need to be updated

--- a/vault/pkg.dendron-engine.qa.md
+++ b/vault/pkg.dendron-engine.qa.md
@@ -2,7 +2,7 @@
 id: 60fbcc05-df2a-44a2-aa0e-cdd62c2557b6
 title: Qa
 desc: ''
-updated: 1630794660527
+updated: 1630796645984
 created: 1614812225185
 ---
 
@@ -56,7 +56,6 @@ test.only("bond", async () => {
 These tests cover everything related to `unified` plugins. This refers to anything in `packages/engine-server/src/markdown/utils.ts`
 
 - plugin tests are located in `packages/engine-test-utils/src/__tests__/engine-server/markdown/`
-- [terminology](https://www.kevinslin.com/notes/09b6c659-3fe3-4a7d-98f9-47e7167cca5b.html) to understand
 - when testing `transformers`, `process` will run over the node that is passed in to the processor
 - when testing `parsers` and `compilers`, `process` will run over the text that you pass into it 
 

--- a/vault/pkg.dendron-engine.qa.md
+++ b/vault/pkg.dendron-engine.qa.md
@@ -2,7 +2,7 @@
 id: 60fbcc05-df2a-44a2-aa0e-cdd62c2557b6
 title: Qa
 desc: ''
-updated: 1628464039086
+updated: 1630794660527
 created: 1614812225185
 ---
 
@@ -53,7 +53,7 @@ test.only("bond", async () => {
 # Topics
 
 ## Unified Tests
-These tests cover everything related to `unified` plugins. This refers to anything in packages/engine-server/src/markdown/utils.ts
+These tests cover everything related to `unified` plugins. This refers to anything in `packages/engine-server/src/markdown/utils.ts`
 
 - plugin tests are located in `packages/engine-test-utils/src/__tests__/engine-server/markdown/`
 - [terminology](https://www.kevinslin.com/notes/09b6c659-3fe3-4a7d-98f9-47e7167cca5b.html) to understand

--- a/vault/pkg.dendron-engine.ref.note-response.md
+++ b/vault/pkg.dendron-engine.ref.note-response.md
@@ -50,4 +50,4 @@ created: 1611160590954
 ```
 
 ## Links
-- [type definition](https://github.com/dendronhq/dendron/blob/master/packages/common-all/src/typesv2.ts#L166:L166)
+- [type definition](https://github.com/dendronhq/dendron/blob/master/packages/common-all/src/types/typesv2.ts)

--- a/vault/pkg.dendron-markdown.arch.md
+++ b/vault/pkg.dendron-markdown.arch.md
@@ -2,7 +2,7 @@
 id: dc72e684-8ff8-4c41-a2f7-93fc14ee0d6a
 title: Arch
 desc: ''
-updated: 1628178827477
+updated: 1630641050455
 created: 1622147759924
 ---
 
@@ -82,10 +82,10 @@ export enum ProcFlavor {
 ### Compilation
 Depending on what output you plan on converting Dendron into, different plugin combinations get invoked.
 
-Dendron has a few different target outputs which are listed [here](https://github.com/dendronhq/dendron/blob/integ-publish/packages/engine-server/src/markdown/types.ts#L45:L45).
+Dendron has a few different target outputs which are listed, under `DendronASTTypes`, [here](https://github.com/dendronhq/dendron/blob/master/packages/engine-server/src/markdown/types.ts).
 
 For everything except HTML, Dendron will call the `compile` of the specific plugin.
 
-For HTML, Dendron will transform `remark` nodes into `rehype`, which means that `compile` methods on `remark` plugins will never be called. If you are writing a custom plugin, use the transformer, `dendronPub` (https://github.com/dendronhq/dendron/blob/dev-kevin/packages/engine-server/src/markdown/remark/dendronPub.ts#L157:L157), which runs after parsing but before compilation to transform the remark nodes into rehype nodes. 
+For HTML, Dendron will transform `remark` nodes into `rehype`, which means that `compile` methods on `remark` plugins will never be called. If you are writing a custom plugin, use the transformer, `dendronPub` (https://github.com/dendronhq/dendron/blob/master/packages/engine-server/src/markdown/remark/dendronPub.ts), which runs after parsing but before compilation to transform the remark nodes into rehype nodes. 
 
 You can see [[Writing a custom Dendron Unified Plugin|pkg.dendron-markdown.cook#writing-a-custom-dendron-unified-plugin]] for more details on this

--- a/vault/pkg.dendron-markdown.cook.md
+++ b/vault/pkg.dendron-markdown.cook.md
@@ -10,4 +10,4 @@ created: 1622148093612
 ### Writing a custom Dendron Unified Plugin
 - status: [[Work In Progress 🚧|dendron.ref.status#work-in-progress-]]
 
-you'll want to create a case statement in dendronPub which takes an anchor and converts it into the corresponding html output. you can see tests for it here: https://github.com/dendronhq/dendron/blob/dev-kevin/packages/engine-test-utils/src/__tests__/engine-server/markdown/dendronPub.spec.ts#L101:L101
+you'll want to create a case statement in dendronPub which takes an anchor and converts it into the corresponding html output. you can see tests for it here: https://github.com/dendronhq/dendron/blob/master/packages/engine-test-utils/src/__tests__/engine-server/markdown/dendronPub.spec.ts

--- a/vault/pkg.dendron-next-server.arch.md
+++ b/vault/pkg.dendron-next-server.arch.md
@@ -2,7 +2,7 @@
 id: a0240c63-2000-4542-a0ba-d570f42323b9
 title: Arch
 desc: ''
-updated: 1628151345970
+updated: 1630793130371
 created: 1622130772977
 ---
 
@@ -24,7 +24,7 @@ There are two kind of views in the plugin that get handled by NextJs:
 Treeviews are components in the sidepanel, webviews are views that are revealed using a command (eg. `Dendron: Configure`). The mechanism of rendering both views are similar and described below.
 
 1. User initiates the view by opening the tree view or issuing the UI command
-1. This brings up a webview with the following [code](https://github.com/dendronhq/dendron/blob/dev-kevin/packages/plugin-core/src/views/utils.ts#L45:L45)
+1. This brings up a webview with the following [code](https://github.com/dendronhq/dendron/blob/master/packages/plugin-core/src/views/utils.ts)
     ```html
     <html> 
     ...
@@ -34,10 +34,10 @@ Treeviews are components in the sidepanel, webviews are views that are revealed 
 1. The `src` is set to be a corresponding page in `/vscode`. We also pass along [[Dendron Engine|pkg.dendron-engine]] parameters as querystrings.
 1. Express will load up the nextjs view as a static asset and it will be rendered inside VSCode using the iframe.
 1. During initialization, the view will connect to the `engine` and hydrate its `redux` store with current notes and IDE related properties (eg. current notes)
-    - the aforementioned properties are passed down to all child component as [props](https://github.com/dendronhq/dendron/blob/dev-kevin/packages/dendron-next-server/pages/_app.tsx#L92:L92)
+    - the aforementioned properties are passed down to all child component as [props](https://github.com/dendronhq/dendron/blob/master/packages/dendron-next-server/pages/_app.tsx)
 
 
-When the view needs to interact with VSCode, it does so by passing messages. We wrote a helper utility that takes care of this, you can see an example of it [here](https://github.com/dendronhq/dendron/blob/dev-kevin/packages/dendron-next-server/pages/vscode/tree-view.tsx#L184:L184)
+When the view needs to interact with VSCode, it does so by passing messages. We wrote a helper utility that takes care of this, you can see an example of it [here](https://github.com/dendronhq/dendron/blob/master/packages/dendron-next-server/pages/vscode/tree-view.tsx)
 
 You can see an example of an UI event propagating back to VSCode [[here|pkg.dendron-next-server.internal#onclick]]
 
@@ -55,7 +55,7 @@ Initial note render, render note using passed in `noteId` via `queryParam.
 As long as the current webview is not closed, changing the active window will cause a message to the webview to update the display. 
 
 ### Images
-To display an image, the [dendronPreview](https://github.com/dendronhq/dendron/blob/dev/packages/engine-server/src/markdown/remark/dendronPreview.ts#L27:L27) plugin will convert image links to links that call `assetGet` API from the [[pkg.dendron-api-server]]
+To display an image, the [dendronPreview](https://github.com/dendronhq/dendron/blob/dev/packages/engine-server/src/markdown/remark/dendronPreview.ts) plugin will convert image links to links that call `assetGet` API from the [[pkg.dendron-api-server]]
 
 This is necessary because static images are contained within the vault whereas image links by default are relative to where the static file is being served (eg. `~/.code/extensions/...`). In addition, whereas both nextjs and expressjs have capabilities to render static assets, there isn't a straightforward way to add static routes dynamically. 
 
@@ -87,14 +87,14 @@ The Dendron Published Site will be the default path published using nextjs. It h
 
 ## Copy and Paste
 
-By default, modifier controls like copy and paste are disabled because we are operating an iframe operating inside a webview. The workaround is described [here](https://github.com/jevakallio/vscode-live-frame#command-key-combinations-copy-paste-select-all-are-disabled). We've implemented it [here](https://github.com/dendronhq/dendron/blob/feature-graph-regex-filter/packages/plugin-core/src/views/utils.ts#L10:L10) so that any webview that uses `WebViewUtils` to generate the HTML will come with the workaround. Make sure that keyboard events are allowed to propagate for this workaround to work. 
+By default, modifier controls like copy and paste are disabled because we are operating an iframe operating inside a webview. The workaround is described [here](https://github.com/jevakallio/vscode-live-frame#command-key-combinations-copy-paste-select-all-are-disabled). We've implemented it [here](https://github.com/dendronhq/dendron/blob/master/packages/plugin-core/src/views/utils.ts) so that any webview that uses `WebViewUtils` to generate the HTML will come with the workaround. Make sure that keyboard events are allowed to propagate for this workaround to work. 
 
 ## Theming
 
-Dendron listens to the [ThemeChange](https://github.com/dendronhq/dendron/blob/feat/preview-mermaid/packages/dendron-next-server/pages/_app.tsx#L107:L107) event from the plugin.
+Dendron listens to the [ThemeChange](https://github.com/dendronhq/dendron/blob/master/packages/dendron-next-server/pages/_app.tsx) event from the plugin.
 
-This is currently broadcasted when we load the webview initially [here](https://github.com/dendronhq/dendron/blob/feat/preview-mermaid/packages/plugin-core/src/views/utils.ts#L77:L77). 
+This is currently broadcasted when we load the webview initially [here](https://github.com/dendronhq/dendron/blob/master/packages/plugin-core/src/views/utils.ts). 
 
 - NOTE: currently, in order to broadcast theme changes, a user needs to run `ReloadWindow`. We have an action item to change this dynamcally. 
 
-On the webview side, Dendron uses the [ThemeSwitcherProvider](https://github.com/dendronhq/dendron/blob/feat/preview-mermaid/packages/dendron-next-server/pages/_app.tsx#L131:L131) to pass the current theme to downstream components
+On the webview side, Dendron uses the [ThemeSwitcherProvider](https://github.com/dendronhq/dendron/blob/master/packages/dendron-next-server/pages/_app.tsx) to pass the current theme to downstream components

--- a/vault/pkg.dendron-next-server.cook.md
+++ b/vault/pkg.dendron-next-server.cook.md
@@ -2,7 +2,7 @@
 id: 1698aef0-efd4-4c92-a3b0-5ca702b228a3
 title: Cook
 desc: ''
-updated: 1624320975618
+updated: 1630792959399
 created: 1621376746723
 ---
 
@@ -19,7 +19,7 @@ created: 1621376746723
 - see [here](https://github.com/dendronhq/dendron/blob/master/packages/plugin-core/src/commands/ConfigureWithUI.ts#L22:L22) for integrating a command with the web ui
 
 ### Integrating a tree view with the plugin
-- see [here](https://github.com/dendronhq/dendron/blob/dev-kevin/packages/plugin-core/src/views/DendronTreeViewV2.ts#L134:L134) for an example
+- see [here](https://github.com/dendronhq/dendron/blob/master/packages/plugin-core/src/views/DendronTreeViewV2.ts) for an example
 
 
 ### Adding a VSCode Webview
@@ -110,5 +110,5 @@ See [[instructions|pkg.dendron-next-server.dev#^MgEdJdyD]] for connecting to a w
 
 ### Passing Query Parameters
 
-- [generating query params](https://github.com/dendronhq/dendron/blob/feat-note-view/packages/dendron-next-server/pages/vscode/note-preview.tsx#L31:L31)
-- [Consuming query params in the view](https://github.com/dendronhq/dendron/blob/feat-note-view/packages/dendron-next-server/pages/vscode/note-preview.tsx#L31:L31)
+- [generating query params](https://github.com/dendronhq/dendron/blob/master/packages/dendron-next-server/pages/vscode/note-preview.tsx)
+- [Consuming query params in the view](https://github.com/dendronhq/dendron/blob/master/packages/dendron-next-server/pages/vscode/note-preview.tsx)

--- a/vault/pkg.dendron-next-server.dev.md
+++ b/vault/pkg.dendron-next-server.dev.md
@@ -59,5 +59,5 @@ Next Steps:
 ### Adding a new web view
 
 The following goes over an example of implementing the `ShowPreviewV2` command
-- [plugin command logic](https://github.com/dendronhq/dendron/blob/release/0.54/packages/plugin-core/src/commands/ShowPreviewV2.ts#L81:L81)
-- [react view logic](https://github.com/dendronhq/dendron/blob/release/0.54/packages/dendron-next-server/pages/vscode/note-preview.tsx#L207:L207)
+- [plugin command logic](https://github.com/dendronhq/dendron/blob/master/packages/plugin-core/src/commands/ShowPreviewV2.ts)
+- [react view logic](https://github.com/dendronhq/dendron/blob/master/packages/dendron-next-server/pages/vscode/note-preview.tsx)

--- a/vault/pkg.dendron-plugin.dev.md
+++ b/vault/pkg.dendron-plugin.dev.md
@@ -2,7 +2,7 @@
 id: 04dd9ad8-3d81-4098-a661-21b6acc6f443
 title: Dev
 desc: ''
-updated: 1629820655294
+updated: 1630732977680
 created: 1621721485330
 ---
 
@@ -35,9 +35,9 @@ Conventions:
 
 ### Create a new Pod
 
-1. setting up dev environment and getting started: <https://dendron.so/notes/81da87be-2d4e-47b5-a1d6-c0d647e1ab00.html>
-2. sample code for json export pod: <https://github.com/dendronhq/dendron/blob/master/packages/pods-core/src/builtin/JSONPod.ts#L143:L143>
-3. what you will get from `prepareNotesForExport`: <https://dendron.so/notes/0db94b86-d5c2-4e70-8f61-1a686fa8cc1d.html>
+1. setting up dev environment and getting started: <https://wiki.dendron.so/notes/81da87be-2d4e-47b5-a1d6-c0d647e1ab00.html>
+2. sample code for json export pod: <https://github.com/dendronhq/dendron/blob/master/packages/pods-core/src/builtin/JSONPod.ts>
+3. what you will get from `prepareNotesForExport`: <https://wiki.dendron.so/notes/0db94b86-d5c2-4e70-8f61-1a686fa8cc1d.html>
 4. anki pod: take notes and transform them to anki format
 
 ## Config
@@ -119,7 +119,7 @@ export class InsertNoteLinkButton extends DendronBtn {
 Pre-requisites:
 - [[Create a new Command|pro.dendron-plugin.cook#create-a-new-command]]
 
-This goes over adding a new command with lookup. To see an example, see this [command](https://github.com/dendronhq/dendron/blob/dev-kevin/packages/plugin-core/src/commands/InsertNoteLink.ts#L1:L1) and this commit: cc8a02b4.
+This goes over adding a new command with lookup. To see an example, see this [command](https://github.com/dendronhq/dendron/blob/master/packages/plugin-core/src/commands/InsertNoteLink.ts) and this commit: `cc8a02b4`.
 
 ```mermaid
 sequenceDiagram
@@ -145,13 +145,13 @@ sequenceDiagram
   - this method is responsible for configuring and instantiating the lookup controller and provider
     - controller controls presentation of the quickinput
     - provider controls the data retrieval behavior 
-    - on success, will return the following [response type](https://github.com/dendronhq/dendron/blob/dev-kevin/packages/plugin-core/src/components/lookup/LookupProviderV3.ts#L39:L39)
+    - on success, will return the following [response type](https://github.com/dendronhq/dendron/blob/master/packages/plugin-core/src/components/lookup/LookupProviderV3.ts)
     - NOTE: because we can't simply block on `showQuickInput`, we return a promise that listens to a `lookupProvider` event with the corresponding `id` of the particular command
 
 ## UI
 ### Adding a Web UI Component
 1. see [[Create a new Command|pro.dendron-plugin.cook#create-a-new-command]] for creating a new command
-1. Add a new entry to [DendronWebViewKey](https://github.com/dendronhq/dendron/blob/dev-kevin/packages/common-all/src/types/typesv2.ts#L486:L486)
+1. Add a new entry to [DendronWebViewKey](https://github.com/dendronhq/dendron/blob/master/packages/common-all/src/types/typesv2.ts)
 1. in `execute`, create a new webview
   ```ts
     const title = //TODO: add panel title
@@ -226,11 +226,11 @@ clipboard.writeText(link);
 
 ### Prompt User for Input using Selection
 
-- see [this](https://github.com/dendronhq/dendron/blob/dev-kevin/packages/plugin-core/src/commands/VaultAddCommand.ts#L1:L1)
+- see [this](https://github.com/dendronhq/dendron/blob/master/packages/plugin-core/src/commands/VaultAddCommand.ts)
 
 ### Prompt User for Input using Free Text
 
-- see [this](https://github.com/dendronhq/dendron/blob/dev-kevin/packages/plugin-core/src/commands/VaultAddCommand.ts#L1:L1)
+- see [this](https://github.com/dendronhq/dendron/blob/master/packages/plugin-core/src/commands/VaultAddCommand.ts)
 
 ```ts
 let out = await VSCodeUtils.showInputBox({
@@ -242,7 +242,7 @@ if (PickerUtilsV2.isStringInputEmpty(out)) return;
 
 ### Get location of the frontmatter
 
-- example [here](https://github.com/dendronhq/dendron/blob/feat/frontmatter-tags/packages/plugin-core/src/services/NoteSyncService.ts#L81:L81)
+- example [here](https://github.com/dendronhq/dendron/blob/master/packages/plugin-core/src/services/NoteSyncService.ts)
 ```
 
 ```
@@ -251,4 +251,4 @@ if (PickerUtilsV2.isStringInputEmpty(out)) return;
 
 ### Upating the cursor position
 
-- see [this](https://github.com/dendronhq/dendron/blob/dev-kevin/packages/plugin-core/src/test/suite-integ/LookupCommand.test.ts#L846:L846)
+- see [this](https://github.com/dendronhq/dendron/blob/master/packages/plugin-core/src/test/suite-integ/NoteLookupCommand.test.ts)

--- a/vault/pkg.dendron-plugin.qa.test.md
+++ b/vault/pkg.dendron-plugin.qa.test.md
@@ -2,7 +2,7 @@
 id: veJtAvr1gSMu50Mp
 title: Test
 desc: ''
-updated: 1629998794634
+updated: 1630796617345
 created: 1627140509315
 ---
 
@@ -12,9 +12,7 @@ When writing a test for new functionality, make sure to consider both the `singl
 
 To write a test, use the `runLegacySingleWorkspaceTest` or `runLegacyMultiWorkspaceTest` methods to setup a mock Dendron workspace of the respective type.
 
-You can see an example of both in [plugin-core/src/test/suite-integ/RenameNoteV2.test.ts](https://github.com/dendronhq/dendron/blob/master/packages/plugin-core/src/test/suite-integ/RenameNoteV2.test.ts#L131:L131)
-
-The arguments are explained [here](https://github.com/dendronhq/dendron/blob/master/packages/plugin-core/src/test/testUtilsV3.ts#L70:L70).
+The arguments are explained [here](https://github.com/dendronhq/dendron/blob/master/packages/plugin-core/src/test/testUtilsV3.ts).
 
 ## Tips
 

--- a/vault/pkg.engine-test-utils.cook.md
+++ b/vault/pkg.engine-test-utils.cook.md
@@ -2,14 +2,14 @@
 id: 9884bdb4-8050-4659-bd51-143940b20db8
 title: Cook
 desc: ''
-updated: 1623255663412
+updated: 1630729645089
 created: 1623255634411
 ---
 
 
 ### Stubbing dendron.yml in a test
 - see [[Engine Test Utils|pkg.engine-test-utils]]
-- see example [here](https://github.com/dendronhq/dendron/blob/dev-kevin/packages/engine-test-utils/src/__tests__/engine-server/markdown/backlinks.spec.ts#L68:L68)
+- see example [here](https://github.com/dendronhq/dendron/blob/master/packages/engine-test-utils/src/__tests__/engine-server/markdown/backlinks.spec.ts)
 
 ```ts
 test("backlink to home page", async () => {


### PR DESCRIPTION
URL validator addition to the repo. This includes an auditor that runs against new PRs, and also includes all the fixes I needed to add based on broken links.

Follow-up issue, based on findings, as it would make sense to make use of a different broken-link checking tool: #183 