### PR TITLE
chore(cli): update error handling for CLI commands

### DIFF
--- a/vault/dendron.dev.arch.md
+++ b/vault/dendron.dev.arch.md
@@ -2,7 +2,7 @@
 id: ENeBSPWAtTlQclXYWNm6c
 title: Architecture
 desc: ''
-updated: 1631834951977
+updated: 1631979440652
 created: 1629988601634
 ---
 
@@ -29,6 +29,7 @@ This goes over the major architectural components of Dendron.
   - Publishing: [[Logic to check if a page can be published|pkg.dendron-engine.t.publishing#logic-to-check-if-a-page-can-be-published]]
   - Markdown: [[pkg.dendron-markdown.arch]]
   - Notes
+  - CLI: [[pkg.dendron-cli.arch]]
 
 ## Other
 - NextJS

--- a/vault/pkg.dendron-cli.arch.md
+++ b/vault/pkg.dendron-cli.arch.md
@@ -1,0 +1,150 @@
+---
+id: sLky6p4DfEp4ll6w9IZ8o
+title: Arch
+desc: ''
+updated: 1631981007457
+created: 1631979441703
+---
+
+## Summary
+
+This goes over how CLI commands are architected in Dendron
+
+## Details
+
+
+All CLI in Dendron extend the `CLICommand` class
+
+```ts
+class CustomCLIComand extends CLICommand  {
+    ...
+}
+```
+
+The basic execution loop of a CLI command is described below
+
+```ts
+eval(args) {
+    {error, ...opts}= @enrichArgs(args)
+    if {error} log(error) && return
+
+    {error, ...out} = @execute(opts)
+    if {error} log(error) && return
+
+    return out
+}
+```
+
+* `enrichArgs` convert the CLI flags into objects, doing any validation as necessary
+    - returned option object is described by `<TOpts>` and typically named `CommandOpts` by convention
+* `execute` runs the logic of the given CLI command
+    - returned output object is described by `<TOut>` and typically named `CommandOutput` by convention
+
+The methods to implement for a CLI command
+
+```ts
+export abstract class CLICommand<
+  TOpts extends CommandCommonProps = CommandCommonProps,
+  TOut extends CommandCommonProps = CommandCommonProps> {
+
+  abstract enrichArgs(args: any): Promise<TOpts>;
+  abstract execute(opts?: TOpts): Promise<TOut>;
+}
+```
+
+
+All commands are initialized in bin/dendron-cli.ts.
+
+```ts
+new VaultCLICommand().buildCmd(buildYargs);
+...
+```
+
+`buildCmd` is responsible for building for creating CLI specific attributes. Child classes call override `buildCmd` to extend with custom options
+
+
+## Case Study
+Lets take a look at the publish command
+
+```sh
+dendron publish <cmd>
+
+commands for publishing notes
+
+Positionals:
+  cmd  a command to run           [string] [required] [choices: "init", "build"]
+
+Options:
+  --version  Show version number                                       [boolean]
+  --help     Show help                                                 [boolean]
+  --wsRoot   location of workspace
+  --vault    name of vault
+  --quiet    do not print output to stdout
+  --dest     override where nextjs-template is located                  [string]
+  --attach   use existing dendron engine instead of spawning a new one [boolean]
+```
+
+### Options
+
+#### Common Options
+
+The following are common for all CLI commands
+
+```sh
+  --version  Show version number                                       [boolean]
+  --help     Show help                                                 [boolean]
+  --quiet    do not print output to stdout
+```
+
+#### Engine Options
+
+All commands that use the Dendron engine will use these options
+
+```sh
+  --wsRoot   location of workspace
+  --vault    name of vault
+  --attach   use existing dendron engine instead of spawning a new one [boolean]
+```
+
+#### Custom Options
+
+In the above example, the following is a custom option
+
+```
+  --dest     override where nextjs-template is located                  [string]
+```
+
+### Option Types
+
+```ts
+// common for all CLI related options and outputs
+type CommandCommonProps = {
+    error?: DendronError
+}
+
+// this is types for the CLI flags
+type CommandCLIOpts =  {
+    ...
+}
+
+// this is returned by `cmd.enrichArgs` Validated and clean version 
+type CommandOpts =  { 
+    ...
+} & CommandCommonProps 
+
+// this is returned by `cmd.execute`
+type CommandOutput = {
+    ...
+} & CommandCommonProps
+```
+
+### Option Generics
+All commands extend from `CLICommand`. `TOpts` stands for `CommandOpts` and `TOut` for `CommandOutput`
+
+```ts
+export abstract class CLICommand<
+  TOpts extends CommandCommonProps = CommandCommonProps,
+  TOut extends CommandCommonProps = CommandCommonProps
+> extends BaseCommand<TOpts, TOut> {
+}
+```

--- a/vault/pkg.dendron-cli.dev.md
+++ b/vault/pkg.dendron-cli.dev.md
@@ -2,7 +2,7 @@
 id: 832a6e4d-4ed9-414f-baa8-d2f20432c934
 title: Dev
 desc: ''
-updated: 1621994598072
+updated: 1631985576213
 created: 1609350672493
 ---
 
@@ -11,6 +11,11 @@ created: 1609350672493
 - [[dendron.dev.setup]] 
 
 ## Cook
+
+### Creating a new CLI Command
+
+See [[Arch|pkg.dendron-cli.arch]]
+
 ### Symlink
 Symlinking `dendron-cli` lets you use the current version of dendron from anywhere inside the CLI
 


### PR DESCRIPTION
This also includes a change to pass along all sockets created by the engine server. Downstream clients can use this to force close all sockets connecting to the current server