### PR TITLE
Update docs for tab switch keybinding

### DIFF
--- a/vault/dendron.faq.md
+++ b/vault/dendron.faq.md
@@ -105,7 +105,7 @@ Dendron automatically saves when you change focus (switch tabs or applications).
 
 There are 3 ways to go back to my previous note:
 
-1. `ctrl-tab` (go to previous tab)
+1. `ctrl-tab` (go to previous tab with default VSCode settings)
 2. click on the previous tab
 3. using the open editors pane
 

--- a/vault/dendron.tutorial.linking-notes.md
+++ b/vault/dendron.tutorial.linking-notes.md
@@ -18,7 +18,7 @@ Resulting Link: [[dendron.tutorial]]
 
 To navigate to the note in the link, you can just click on the link in the preview pane. In the editor pane, you can move the cursor into the link and hit `Ctrl+Enter / Cmd+Enter`.
 
-You can switch back to the previous note by pressing `Ctrl+Tab / Cmd+Tab`
+You can switch back to the previous note with the tab switching shortcut (`Ctrl+Tab` on most systems).
 
 #### Backlinks
 


### PR DESCRIPTION
# docs: keybinding reference for tab switching

`dendron` PR: https://github.com/dendronhq/dendron/pull/1453

Noticed that the "unique to your system" ctrl/cmd key wasn't applicable for tab switching. Made an extra note as I (and perhaps many others too) have specific key bindings to match the defaults across other apps:

```
    {
        "key": "ctrl+shift+tab",
        "command": "workbench.action.previousEditor"
    },
    {
        "key": "ctrl+tab",
        "command": "workbench.action.nextEditor"
    },
```