### PR TITLE
Docs for cli telemetry support

### DIFF
--- a/vault/dendron.dev.cli.md
+++ b/vault/dendron.dev.cli.md
@@ -2,7 +2,7 @@
 id: Y0cZsmfUdytwajRGeylMZ
 title: CLI
 desc: ''
-updated: 1632241348526
+updated: 1634011214546
 created: 1631473249667
 ---
 
@@ -16,8 +16,7 @@ commands related to development of Dendron
 Positionals:
   cmd  a command to run
       [string] [required] [choices: "generate_json_schema_from_config", "build",
-      "bump_version", "publish", "sync_assets", "prep_plugin", "package_plugin",
-                                                               "install_plugin"]
+      "bump_version", "publish", "sync_assets", "prep_plugin", "package_plugin", "install_plugin", "enable_telemetry", "disable_telemetry", "show_telemetry"]
 
 Options:
   --version           Show version number                              [boolean]
@@ -83,3 +82,15 @@ Install latest vsix in all local vscode versions
 
 <!-- Citations -->
 [^upgrade]: [[upgradeType|dendron.dev.cli#upgradetype]]
+
+### enable_telemetry
+
+Enables telemetry. This also affects telemetry while using Dendron in VSCode.
+
+### disable_telemetry
+
+Disables telemetry. This also affects telemetry while using Dendron in VSCode.
+
+### show_telemetry
+
+Shows telemetry notice.

--- a/vault/dendron.ref.telemetry.md
+++ b/vault/dendron.ref.telemetry.md
@@ -2,7 +2,7 @@
 id: 84df871b-9442-42fd-b4c3-0024e35b5f3c
 title: Telemetry
 desc: ''
-updated: 1633964370400
+updated: 1634011275013
 created: 1619460500071
 ---
 
@@ -140,7 +140,7 @@ When telemetry is disabled or enabled, we collect information about the event to
 If you've disabled telemetry from the [Visual Studio Code Telemetry setting](https://code.visualstudio.com/docs/getstarted/telemetry), no further action is needed. You can set this option in your workspace settings, or user settings.
 
 To disable telemetry in Dendron specifically, run the [[Disable Telemetry|dendron.topic.commands#disable-telemetry]] command.
-You can also set telemetry using the cli by using the [[Telemetry Commands|dendron.topic.cli#telemetry-commands]]. 
+You can also disable telemetry using the cli by using the [[disable_telemetry|dendron.dev.cli#disable_telemetry]] command. 
 
 ## Why not have opt-in telemetry?
 

--- a/vault/dendron.topic.cli.md
+++ b/vault/dendron.topic.cli.md
@@ -306,38 +306,3 @@ Run `git add . && git commit` on all vaults inside the workspace
 #### sync
 
 Run `addAndCommit`, `pull`, and `push` on all vaults inside the workspace. This follows the same configuration as the `Workspace: Sync` command in the extension, see [[Workspace Sync|dendron.ref.workspace#Workspace: Sync]] for details.
-
-## Telemetry Commands
-
-
-```sh
-dendron telemetry <cmd>
-
-enable or disable telemetry
-
-Positionals:
-  cmd  a command to run
-                      [string] [required] [choices: "enable", "disable", "show"]
-
-Options:
-  --version  Show version number                                       [boolean]
-  --help     Show help                                                 [boolean]
-  --wsRoot   location of workspace
-  --vault    name of vault
-  --quiet    don't print output to stdout
-
-```
-
-### Actions
-
-#### enable
-
-Enables telemetry. This also affects telemetry while using Dendron in VSCode.
-
-#### disable
-
-Disables telemetry. This also affects telemetry while using Dendron in VSCode.
-
-#### show
-
-Shows telemetry notice.


### PR DESCRIPTION
This PR adds
- Docs for the new cli commands `dendron telemetry enable`, `dendron telemetry disable`, `dendron telemetry show`
- Docs for the new metrics added for cli telemetry support. 