### PR TITLE
Fix typo in GH action config example

### DIFF
--- a/vault/dendron.topic.publishing.github.md
+++ b/vault/dendron.topic.publishing.github.md
@@ -89,7 +89,7 @@ jobs:
               run: npm install
 
             - name: Build pod
-              run: npm run dendron-cli -- buildSiteV2 --wsRoot .  --stage prod
+              run: npm run dendron-cli --buildSiteV2 --wsRoot .  --stage prod
 
             - name: Deploy site
               uses: peaceiris/actions-gh-pages@v3


### PR DESCRIPTION
Fixed a typo in the dendron-cli call which would cause a 'no such file or directory' error when attempting to build the site