### PR TITLE
Fix GitHub Action dendron-build: Build NextJS site on PRs, and don't publish to GitHub Pages

### DIFF
--- a/.github/workflows/dendron-action.yml
+++ b/.github/workflows/dendron-action.yml
@@ -5,6 +5,12 @@ on:
     branches:
     - master
     - main
+    - dev
+  pull_request:
+    branches:
+    - master
+    - main
+    - dev
 
 jobs:
   build:
@@ -21,14 +27,9 @@ jobs:
     - name: Print version
       run: yarn dendron-cli -- --version
 
-    - name: Build pod
-      run: LOG_LEVEL=info yarn dendron-cli -- buildSiteV2 --wsRoot .  --stage prod
-
-    - name: Deploy site
-      uses: peaceiris/actions-gh-pages@v3
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_branch: pages
-        publish_dir: docs/
-        force_orphan: true
-        cname: "dendron.so"
+    - name: Build NextJS site
+      run: |
+        echo 'init dendron next' && npx dendron publish init
+        echo 'install deps...' && cd .next && yarn && cd ..
+        echo 'version check...' && npx dendron --version
+        echo 'build and export...' && npx dendron publish export


### PR DESCRIPTION
> Starting with pushing this to `dev`, then will merge this change into `master`

- `dendron-site` is no longer being published to GitHub Pages
- The GitHub Action is still valuable in ensuring that a PR or push won't break the website
  - Every PR will not only trigger the URL validator, but will also trigger a build of the website to make sure breaking changes aren't introduced