### PR TITLE
Make special note lookup keybinds more obvious

### DIFF
--- a/vault/dendron.topic.special-notes.md
+++ b/vault/dendron.topic.special-notes.md
@@ -23,7 +23,7 @@ By default, it will create the journal under `daily.{date}` though this is confi
 
 A journal note is a self contained note that is meant to track something over time. Examples of journals include recording **workout sessions**, making **meeting notes**, and keeping a **mood journal**.
 
-To create a journal note, trigger a lookup and then click on the calendar icon, or use the keybind "ctrl+shift+j"/"cmd+shift+j" (depending on operating system).
+To create a journal note, trigger a lookup and then click on the calendar icon, or use the `Ctrl+Shift+J`/`Cmd+Shift+J` shortcut (depending on operating system).
 
 <a href="https://www.loom.com/share/3c3ddc1dc63547cea8bf186bec31f71b"> 
 <img style="" src="https://cdn.loom.com/sessions/thumbnails/3c3ddc1dc63547cea8bf186bec31f71b-with-play.gif"> </a>

--- a/vault/dendron.topic.special-notes.md
+++ b/vault/dendron.topic.special-notes.md
@@ -23,7 +23,7 @@ By default, it will create the journal under `daily.{date}` though this is confi
 
 A journal note is a self contained note that is meant to track something over time. Examples of journals include recording **workout sessions**, making **meeting notes**, and keeping a **mood journal**.
 
-To create a journal note, trigger a lookup and then click on the calendar icon.
+To create a journal note, trigger a lookup and then click on the calendar icon, or use the keybind "ctrl+shift+j"/"cmd+shift+j" (depending on operating system).
 
 <a href="https://www.loom.com/share/3c3ddc1dc63547cea8bf186bec31f71b"> 
 <img style="" src="https://cdn.loom.com/sessions/thumbnails/3c3ddc1dc63547cea8bf186bec31f71b-with-play.gif"> </a>
@@ -34,12 +34,14 @@ A reference for date formatting tokens can be found [here](https://moment.github
 
 ## Scratch Note
 
-A scratch note is a self contained note that is meant to be used as scratchpad. Use it for thoughts or when you want to expand on a bullet point. Scratch notes are created in the `scratch` domain and have the following format: `scratch.{y.MM.dd.HHmmss}`.
+A scratch note is a self contained note that is meant to be used as scratchpad. Use it for thoughts or when you want to expand on a bullet point. Scratch notes are created in the `scratch` domain and have the following format: `scratch.{y.MM.dd.HHmmss}`. To create a scratch note, trigger a lookup and then click the "create scratch note" icon, or use the keybind "ctrl+shift+s"/"cmd+shift+s" (depending on operating system).
 
 <a href="https://www.loom.com/share/2fd3042119124df8bb4592d8ffe6d708"> 
 <img style="" src="https://cdn.loom.com/sessions/thumbnails/2fd3042119124df8bb4592d8ffe6d708-with-play.gif"> </a>
 
 ## Configuration
+
+To change the keybindings used to create special notes, you can [define custom shortcuts](https://wiki.dendron.so/notes/66d734d2-07bd-4ac6-be0b-a38b55bc1099/) in `keybindings.json` that will [modify the behaviour of the lookup command](https://wiki.dendron.so/notes/ad270a7d-2aed-4273-8319-eb6536e38b29/).
 
 All special notes support the following configuration options
 

--- a/vault/dendron.topic.special-notes.md
+++ b/vault/dendron.topic.special-notes.md
@@ -41,7 +41,7 @@ A scratch note is a self contained note that is meant to be used as scratchpad. 
 
 ## Configuration
 
-To change the keybindings used to create special notes, you can [define custom shortcuts](https://wiki.dendron.so/notes/66d734d2-07bd-4ac6-be0b-a38b55bc1099/) in `keybindings.json` that will [modify the behaviour of the lookup command](https://wiki.dendron.so/notes/ad270a7d-2aed-4273-8319-eb6536e38b29/).
+To change the keybindings used to create special notes, you can [[define custom shortcuts|dendron.topic.lookup.keybindings]] in `keybindings.json` that will [[modify the behavior of the `Lookup` command|dendron.topic.lookup.modifiers]].
 
 All special notes support the following configuration options
 

--- a/vault/dendron.topic.special-notes.md
+++ b/vault/dendron.topic.special-notes.md
@@ -34,7 +34,7 @@ A reference for date formatting tokens can be found [here](https://moment.github
 
 ## Scratch Note
 
-A scratch note is a self contained note that is meant to be used as scratchpad. Use it for thoughts or when you want to expand on a bullet point. Scratch notes are created in the `scratch` domain and have the following format: `scratch.{y.MM.dd.HHmmss}`. To create a scratch note, trigger a lookup and then click the "create scratch note" icon, or use the keybind "ctrl+shift+s"/"cmd+shift+s" (depending on operating system).
+A scratch note is a self contained note that is meant to be used as scratchpad. Use it for thoughts or when you want to expand on a bullet point. Scratch notes are created in the `scratch` domain and have the following format: `scratch.{y.MM.dd.HHmmss}`. To create a scratch note, trigger a lookup and then click the "create scratch note" icon, or use the keybind `Ctrl+Shift+S`/`Cmd+Shift+S` (depending on operating system).
 
 <a href="https://www.loom.com/share/2fd3042119124df8bb4592d8ffe6d708"> 
 <img style="" src="https://cdn.loom.com/sessions/thumbnails/2fd3042119124df8bb4592d8ffe6d708-with-play.gif"> </a>


### PR DESCRIPTION
Although Dendron can be configured to create special notes using keybindings, this is not readily apparent in the documentation on special notes (see [issue #1730](https://github.com/dendronhq/dendron/issues/1730)). Here I propose minimal changes to the documentation that aim to make it clearer that this behavior can be configured, and also that there are already default keybindings for creating special notes. I've also added links to the other relevant parts of the documentation that detail this process.

I wasn't sure exactly what style to use for describing keybindings and how to handle differences across operating systems, but I think the style I've used here is at least reasonable. Also, I'm not actually sure what the default keybindings for these are on MacOS, though I'm pretty sure my guess isn't far off.