### PR TITLE
Early seed 0.69.2

### DIFF
--- a/vault/changelog.early-seed.md
+++ b/vault/changelog.early-seed.md
@@ -2,10 +2,10 @@
 id: 3abd00eb-1c1e-4253-aaf5-dcbe20c21850
 title: Early Seed
 desc: ''
-updated: 1636743874675
+updated: 1637346704939
 created: 1604539200840
 published: true
 nav_exclude: true
 ---
 
-![[changelog#0682:#0680]]
+![[changelog#0691:#0690]]

--- a/vault/changelog.early-seed.md
+++ b/vault/changelog.early-seed.md
@@ -2,10 +2,10 @@
 id: 3abd00eb-1c1e-4253-aaf5-dcbe20c21850
 title: Early Seed
 desc: ''
-updated: 1637346704939
+updated: 1637354754970
 created: 1604539200840
 published: true
 nav_exclude: true
 ---
 
-![[changelog#0691:#0690]]
+![[changelog#0692:#0690]]

--- a/vault/changelog.md
+++ b/vault/changelog.md
@@ -2,12 +2,12 @@
 id: 9bc92432-a24c-492b-b831-4d5378c1692b
 title: Changelog
 desc: ''
-updated: 1637353993062
+updated: 1637354798833
 created: 1601508213606
 nav_order: 2
 ---
 
-## 0.69.1
+## 0.69.2
 
 ### Features
 - feat(workspace): Initialize Workspace command can create native workspaces ([[docs|dendron.topic.workspace.native]]) (#1701) @kaan
@@ -23,13 +23,17 @@ nav_order: 2
 - enhance(lookup) Add description field to lookup buttons (#1735) @tuling
 
 ### Fix
-- fix(pods): invalid configuration error @kevin
 - fix(lookup): have schema exact match suggestion in lookup show up at the top of the list (#1720) @nickolay
 - fix(lookup): disappearing vaults in vault selection quickpick (#1717) @hikchoi
 - fix(publish): remove duplicate CSS (#1707) [`@l2dy`](https://github.com/l2dy)
 - fix(workspace): remove trailing whitespace in note (#1736) [`@l2dy`](https://github.com/l2dy)
 - fix(workspace): decorations working for long notes (#1725) @kaan
 - fix(cli): [ajv](https://github.com/ajv-validator/ajv) (a JSON schema validator) now prints warning messages to console (#1722) @nickolay
+
+## 0.69.1
+
+### Fix
+- fix(pods): invalid configuration error @kevin
 
 ## 0.69.0
 

--- a/vault/changelog.md
+++ b/vault/changelog.md
@@ -2,7 +2,7 @@
 id: 9bc92432-a24c-492b-b831-4d5378c1692b
 title: Changelog
 desc: ''
-updated: 1637353940539
+updated: 1637353993062
 created: 1601508213606
 nav_order: 2
 ---
@@ -29,7 +29,7 @@ nav_order: 2
 - fix(publish): remove duplicate CSS (#1707) [`@l2dy`](https://github.com/l2dy)
 - fix(workspace): remove trailing whitespace in note (#1736) [`@l2dy`](https://github.com/l2dy)
 - fix(workspace): decorations working for long notes (#1725) @kaan
-- fix: [ajv](https://github.com/ajv-validator/ajv) (a JSON schema validator) now prints warning messages to console (#1722) @nickolay
+- fix(cli): [ajv](https://github.com/ajv-validator/ajv) (a JSON schema validator) now prints warning messages to console (#1722) @nickolay
 
 ## 0.69.0
 

--- a/vault/changelog.md
+++ b/vault/changelog.md
@@ -2,7 +2,7 @@
 id: 9bc92432-a24c-492b-b831-4d5378c1692b
 title: Changelog
 desc: ''
-updated: 1637346660450
+updated: 1637353940539
 created: 1601508213606
 nav_order: 2
 ---
@@ -16,7 +16,7 @@ nav_order: 2
 - enhance(markdown): expose `desc` frontmatter property for variable substitution (([[docs|dendron.topic.markdown#frontmatter-variable-substitution]]) (#1721) @hikchoi
   - View the [difference](https://github.com/dendronhq/dendron-site/pull/284/files)
 - enhance(workspace): improved task note decorations @kaan
-  * Task note decorations are colored with the same color as the link to make them easier to distinguish from regular text. ([[docs|]])
+  * Task note decorations are colored with the same color as the link to make them easier to distinguish from regular text. ([[docs|dendron.topic.tasks#task-note-links]])
   * Task notes say `priority:` instead of `prio:` for priorities in task note frontmatter. ([[docs|dendron.topic.tasks#task-note-internals]])
 - enhance(publish): better position sidebar, main content and footer (#1696) @felipe
 - enhance(commands): copy a tag note link results in hashtags (#1687) @joshi

--- a/vault/changelog.md
+++ b/vault/changelog.md
@@ -2,10 +2,34 @@
 id: 9bc92432-a24c-492b-b831-4d5378c1692b
 title: Changelog
 desc: ''
-updated: 1637083041974
+updated: 1637346660450
 created: 1601508213606
 nav_order: 2
 ---
+
+## 0.69.1
+
+### Features
+- feat(workspace): Initialize Workspace command can create native workspaces ([[docs|dendron.topic.workspace.native]]) (#1701) @kaan
+
+### Enhancements
+- enhance(markdown): expose `desc` frontmatter property for variable substitution (([[docs|dendron.topic.markdown#frontmatter-variable-substitution]]) (#1721) @hikchoi
+  - View the [difference](https://github.com/dendronhq/dendron-site/pull/284/files)
+- enhance(workspace): improved task note decorations @kaan
+  * Task note decorations are colored with the same color as the link to make them easier to distinguish from regular text. ([[docs|]])
+  * Task notes say `priority:` instead of `prio:` for priorities in task note frontmatter. ([[docs|dendron.topic.tasks#task-note-internals]])
+- enhance(publish): better position sidebar, main content and footer (#1696) @felipe
+- enhance(commands): copy a tag note link results in hashtags (#1687) @joshi
+- enhance(lookup) Add description field to lookup buttons (#1735) @tuling
+
+### Fix
+- fix(pods): invalid configuration error @kevin
+- fix(lookup): have schema exact match suggestion in lookup show up at the top of the list (#1720) @nickolay
+- fix(lookup): disappearing vaults in vault selection quickpick (#1717) @hikchoi
+- fix(publish): remove duplicate CSS (#1707) [`@l2dy`](https://github.com/l2dy)
+- fix(workspace): remove trailing whitespace in note (#1736) [`@l2dy`](https://github.com/l2dy)
+- fix(workspace): decorations working for long notes (#1725) @kaan
+- fix: [ajv](https://github.com/ajv-validator/ajv) (a JSON schema validator) now prints warning messages to console (#1722) @nickolay
 
 ## 0.69.0
 

--- a/vault/dendron.topic.tasks.md
+++ b/vault/dendron.topic.tasks.md
@@ -2,7 +2,7 @@
 id: SEASewZSteDK7ry1AshNG
 title: Tasks
 desc: ''
-updated: 1635494320717
+updated: 1637353918133
 created: 1635451738215
 ---
 
@@ -68,25 +68,41 @@ edit the task note and change the status to `x` to display a completed checkmark
 
 ### Task note internals
 
-Here's how the first task in the screenshot above looks like in the frontmatter:
-
-```
+```yaml
 ---
 id: sEnzNEw04L4BZ2lN00zuI
-title: Prepare Report
-desc: ''
+title: Task Example
+desc: 'This is an example of task note frontmatter'
 updated: 1635228981637
 created: 1635228506689
-status: ''
+status: 'x'
 due: '2021.10.29'
 priority: 'H'
 owner: 'kaan'
+tags:
+  - size.small
 ---
 ```
 
+#### Task note links
+
+When referencing a task note, rendering works differently when compared to other checkboxes in Markdown. Using the above example as a referenced note at `task.example`:
+
+```markdown
+- [x] This is a task without note links
+- [ ] This is a task with a [[referenced wikilink|dendron.topic.tasks]]
+- [x] [[task note|task.example]] due:wed @kaan prio:high
+  - The checkbox is automatically rendered from the `task.example` frontmatter values for task notes. `due:2021.10.29 @kaan prio:high`, along with the `[x]` prefix, is automatically rendered in the workspace editor.
+    - `@kaan`: Comes from `owner: 'alice'` in the `task.example` frontmatter
+    - `prio:high`: Comes from `priority: 'H'` in the `task.example` frontmatter
+    - `due:2021.10.29`: Comes from `due: 'wed'` in the `task.example` frontmatter
+```
+
+#### Custom configuration
+
 You can see how the task note displays the keys like due and owner. Some like the status and priority are a little more complicated, but you can figure them out once you take a look at the default configuration.
 
-```
+```yaml
 workspace:
     ...
     task:


### PR DESCRIPTION
- Early seed changelog for `0.69.1` and `0.69.2`
- Expanded `dendron.topic.tasks` docs to include rendering differences compared to regular checkmarks/checkboxes, standard note links, and task note links