### PR TITLE
Add section on preview setting for dark themes

### DIFF
--- a/vault/dendron.tutorial.rich-formatting.md
+++ b/vault/dendron.tutorial.rich-formatting.md
@@ -59,6 +59,11 @@ sequenceDiagram
     John->>Bob: How about you?
     Bob-->>John: Jolly good!
 ```
+#### Mermaid Markdown Preview Configuration
+For mermaid diagrams to be properly visible when using a dark VSCode color theme, add the following line to `settings.json`:
+```json
+"markdown-preview-enhanced.mermaidTheme": "dark",
+```
 
 ### Note References
 


### PR DESCRIPTION
I added a small subsection to this doc on how to configure the way the markdown preview renders mermaid diagrams so that they're visible when using dark themes.
I was having problems with this and someone on the [discord told me about this setting,](https://discord.com/channels/717965437182410783/735365126227493004/912923042286542910), but I wasn't able to find any reference to it in the existing docs.

I'm not sure if it'll always be this way, but thought it might be good to put this in since it works this way for now.