### PR TITLE
Early seed 0.72.1

### DIFF
--- a/.brokignore
+++ b/.brokignore
@@ -14,3 +14,5 @@ https://github.com/dendronhq/dendron-site/edit/
 https://github.com/dendronhq/dendron-backend/
 https://www.slant.co/topics/4962/viewpoints/44/~personal-knowledge-base-apps~dendron
 https://org-dendron-public-assets.s3.amazonaws.com/publish/
+https://support.airtable.com/hc/en-us/sections/360009623014-API
+https://support.airtable.com/hc/en-us/articles/219046777-How-do-I-get-my-API-key

--- a/vault/changelog.early-seed.md
+++ b/vault/changelog.early-seed.md
@@ -2,10 +2,10 @@
 id: 3abd00eb-1c1e-4253-aaf5-dcbe20c21850
 title: Early Seed
 desc: ''
-updated: 1638554624301
+updated: 1639156819296
 created: 1604539200840
 published: true
 nav_exclude: true
 ---
 
-![[changelog#0714:#0710]]
+![[changelog#0721:#0720]]

--- a/vault/changelog.md
+++ b/vault/changelog.md
@@ -2,7 +2,7 @@
 id: 9bc92432-a24c-492b-b831-4d5378c1692b
 title: Changelog
 desc: ''
-updated: 1639157099154
+updated: 1639157815655
 created: 1601508213606
 nav_order: 2
 ---
@@ -11,7 +11,7 @@ nav_order: 2
 
 ### Features
 - feat(commands): find broken links ([[dendron://dendron.dendron-site/dendron.ref.commands#findbrokenlinks]]) (#1847) @hikchoi
-- feat(notes): Note Trait System Prototype (Phase 1) (#1658) @jonathan
+- feat(notes): Note Trait System Prototype (Phase 1) ([[dendron://dendron.dendron-site/dendron.topic.traits.quickstart]]) (#1658) @jonathan
 
 ### Enhancements
 - enhance(pods): small tweaks to pod v2 UI (#1857) @jonathan

--- a/vault/changelog.md
+++ b/vault/changelog.md
@@ -2,10 +2,23 @@
 id: 9bc92432-a24c-492b-b831-4d5378c1692b
 title: Changelog
 desc: ''
-updated: 1638893699750
+updated: 1639157099154
 created: 1601508213606
 nav_order: 2
 ---
+
+## 0.72.1
+
+### Features
+- feat(commands): find broken links ([[dendron://dendron.dendron-site/dendron.ref.commands#findbrokenlinks]]) (#1847) @hikchoi
+- feat(notes): Note Trait System Prototype (Phase 1) (#1658) @jonathan
+
+### Enhancements
+- enhance(pods): small tweaks to pod v2 UI (#1857) @jonathan
+- enhance(publish): Fallback to default SEO image if no image is set for published pages. (#1854) @tuling
+
+### Fix
+- fix(views): double open link from preview (#1868) @nickolay
 
 ## 0.72.0
 

--- a/vault/dendron.topic.traits.api.md
+++ b/vault/dendron.topic.traits.api.md
@@ -2,13 +2,13 @@
 id: oOIEFJc6DTgS71mmh89WQ
 title: API
 desc: ''
-updated: 1638860903879
+updated: 1639157690633
 created: 1638844803983
 ---
 
 This contains API documentation for trait behavior. 
 
-> ❗️ Note: This is an experimental API that may have breaking changes in future iterations. An increased API surface exposing more types of functionality for traits are planned in future iterations.
+![[dendron://dendron.dendron-site/tags.stage.germ]]
 
 With note traits, you can optionally override behavior for notes during their creation or modification by implementing callback functionality as detailed below. All behavior is optional - if you do not want to override a certain behavior, you can simply delete that function property from the Javascript trait definition file.
 

--- a/vault/dendron.topic.traits.quickstart.md
+++ b/vault/dendron.topic.traits.quickstart.md
@@ -2,13 +2,13 @@
 id: EQoaBI8A0ZcswKQC3UMpO
 title: Quickstart
 desc: ''
-updated: 1638860823247
+updated: 1639157723576
 created: 1638843110902
 ---
 
 This example will show you how you can create your own note traits and apply them to your new notes.  In this example, we'll create a trait that will modify the name and title of the note automatically when you create a new note.
 
-> ❗️ Note: This is an experimental feature that may have breaking changes in future iterations.
+![[dendron://dendron.dendron-site/tags.stage.germ]]
 
 ### Create a new Note Trait
 

--- a/vault/tags.stage.germ.md
+++ b/vault/tags.stage.germ.md
@@ -2,8 +2,8 @@
 id: J6CKDqxWwcpve4CrpF5aa
 title: Germ
 desc: ''
-updated: 1634752477506
+updated: 1639157306728
 created: 1634752450970
 ---
 
-A germ is a feature that is still in the gestation period. 
+> ❗️ Note: This is an experimental feature that may have breaking changes in future iterations. A germ is a feature that is still in the gestation period.


### PR DESCRIPTION
- Early seed 0.72.1 changelog
- Includes minor updates requested from #315
- Add some airtable links to `.brokignore` that kept providing `403`, even though normally accessible links