### PR TITLE
Documents workflow for private and shared notes

### DIFF
--- a/vault/dendron.guides.workflows.private-shared-setup.md
+++ b/vault/dendron.guides.workflows.private-shared-setup.md
@@ -34,7 +34,7 @@ Create a blank worspace that will have [[multiple vaults|dendron.topic.multi-vau
       2. Select `local`
       3. Type the location where you want it to be stored
       4. Type the name of the vault (can be different from the folder's name)
-   2. Add a **remote vault** for notes that will be shared (either with yourself or with others) you can either clone a remote note or create a local vault and then convert it into a remote one:
+   2. Add a **remote vault** for notes that will be shared (either with yourself or with others). You can clone a remote vault or create a local vault that you convert into a remote one:
       1. If adding remote vault(s) that already exist: 
          1. Run `Dendron: Vault Add`
          2. Select `remote`

--- a/vault/dendron.guides.workflows.private-shared-setup.md
+++ b/vault/dendron.guides.workflows.private-shared-setup.md
@@ -1,0 +1,46 @@
+---
+id: 6DZiBObwhZNYRjnokQ422
+title: Private and shared vaults
+desc: Using Dendron for private and shared use
+updated: 1639167925364
+created: 1638820992694
+---
+
+## Use case
+
+You want to use dendron for personal and professional use, keeping some notes private, while sharing others with other team members (or even yourself! -i.e. different machines). Some of these notes, in turn, may be [[published|dendron.topic.publish]], whereas others, not.
+
+## Overview
+
+Create a blank worspace that will have [[multiple vaults|dendron.topic.multi-vault]]. , each of them serving different purposes and audiences. Some of all of this vaults can be independent git repositories that can be shared with others as you would with a regular git repo. The workspace, in turn, can also be a git repo itself.
+
+## Step by step
+
+### Start from scratch
+
+1. **Create a [[bare workspace|dendron.topic.workspace#concepts]]**. This workspace will be blank and contain all the needeed [[vaults|dendron.topic.vaults]] as well as the templates and configurations.
+   1. Run `Dendron: Initialize Workspace` command.
+   2. Type the location where you want it to be stored
+   3. Select `blank`
+2. Add as many [[dendron.topic.vaults]] as needed, each one serving different purposes or audiences:
+   1. Create a local note for notes that will not be shared:
+      1. Run `Dendron: Vault Add`
+      2. Select `local`
+      3. Type the location where you want it to be stored
+      4. Type the name of the vault (can be different from the folder's name)
+   2. Add a remote vault for notes that will be shared (either with yourself or with others) you can either clone a remote note or create a local vault and then convert it into a remote one:
+      1. Adding a remote vault: 
+         1. Run `Dendron: Vault Add`
+         2. Select `remote`
+         3. Write the git location of the remote vault you want to clone
+         4. The vault will be cloned inside your workspace
+      2. Converting a local vault into a remote vault:
+         1. Run
+3. Write content
+   1. Make sure you add notes into the correspondent vault
+4. Syncronize notes by running `Dendron: Worskpace sync`
+
+
+
+
+

--- a/vault/dendron.guides.workflows.private-shared-setup.md
+++ b/vault/dendron.guides.workflows.private-shared-setup.md
@@ -2,7 +2,7 @@
 id: 6DZiBObwhZNYRjnokQ422
 title: Private and shared vaults
 desc: Using Dendron for private and shared use
-updated: 1639239658911
+updated: 1639240128274
 created: 1638820992694
 ---
 
@@ -48,7 +48,9 @@ Create a blank worspace that will have [[multiple vaults|dendron.topic.multi-vau
 4. Synchronize notes by running `Dendron: Worskpace sync`
    ![[dendron.topic.workspace#syncing-your-workspace-with-git]]
 
+## Acknowledgement
 
+This guide is based on [this gist](https://gist.github.com/kevinslin/0e0f13fedb43732e86938ab1033b7efd)
 
 
 

--- a/vault/dendron.guides.workflows.private-shared-setup.md
+++ b/vault/dendron.guides.workflows.private-shared-setup.md
@@ -35,7 +35,7 @@ Create a blank worspace that will have [[multiple vaults|dendron.topic.multi-vau
       3. Type the location where you want it to be stored
       4. Type the name of the vault (can be different from the folder's name)
    2. Add a **remote vault** for notes that will be shared (either with yourself or with others) you can either clone a remote note or create a local vault and then convert it into a remote one:
-      1. Adding a remote vault: 
+      1. If adding remote vault(s) that already exist: 
          1. Run `Dendron: Vault Add`
          2. Select `remote`
          3. Write the git location of the remote vault you want to clone

--- a/vault/dendron.guides.workflows.private-shared-setup.md
+++ b/vault/dendron.guides.workflows.private-shared-setup.md
@@ -40,7 +40,7 @@ Create a blank worspace that will have [[multiple vaults|dendron.topic.multi-vau
          2. Select `remote`
          3. Write the git location of the remote vault you want to clone
          4. The vault will be cloned inside your workspace
-      2. Converting a local vault into a remote vault:
+      2. If converting local vault(s) into remote vault(s):
          1. Run `Dendron: Convert Vault`
          2. Select the name of your local vault that you want to convert
          3. Select `Convert to remote vault`

--- a/vault/dendron.guides.workflows.private-shared-setup.md
+++ b/vault/dendron.guides.workflows.private-shared-setup.md
@@ -2,7 +2,7 @@
 id: 6DZiBObwhZNYRjnokQ422
 title: Private and shared vaults
 desc: Using Dendron for private and shared use
-updated: 1639240128274
+updated: 1639246566164
 created: 1638820992694
 ---
 
@@ -19,6 +19,8 @@ Some specific use cases in which following a [[dendron.topic.multi-vault]] strat
 Create a blank worspace that will have [[multiple vaults|dendron.topic.multi-vault]], each of them serving different purposes and audiences. Some of them, or even all of them can be independent git repositories that can be shared with others as you would with a regular git repo. The workspace, in turn, can also be a git repo itself.
 
 ## Step by step
+
+### Start from scratch
 
 1. **Create a [[bare workspace|dendron.topic.workspace#concepts]]**. This workspace will be blank and contain all the needeed [[vaults|dendron.topic.vaults]] as well as the templates and configurations.
    ![[dendron.topic.workspace#bare-workspace:#*]]
@@ -47,6 +49,13 @@ Create a blank worspace that will have [[multiple vaults|dendron.topic.multi-vau
    ![[dendron.topic.multi-vault#lookup:#prompt-for-vault-selection-each-time]]
 4. Synchronize notes by running `Dendron: Worskpace sync`
    ![[dendron.topic.workspace#syncing-your-workspace-with-git]]
+
+### Use template
+
+Alternatively, you can use this template from the [[Teams page|dendron.topic.teams]]:
+
+![[dendron.topic.teams#workspace:#*]]
+
 
 ## Acknowledgement
 

--- a/vault/dendron.guides.workflows.private-shared-setup.md
+++ b/vault/dendron.guides.workflows.private-shared-setup.md
@@ -2,43 +2,51 @@
 id: 6DZiBObwhZNYRjnokQ422
 title: Private and shared vaults
 desc: Using Dendron for private and shared use
-updated: 1639167925364
+updated: 1639239658911
 created: 1638820992694
 ---
 
-## Use case
+## Rationale
 
 You want to use dendron for personal and professional use, keeping some notes private, while sharing others with other team members (or even yourself! -i.e. different machines). Some of these notes, in turn, may be [[published|dendron.topic.publish]], whereas others, not.
 
+Some specific use cases in which following a [[dendron.topic.multi-vault]] strategy would be recommended are:
+
+![[dendron.topic.multi-vault#use-cases,1:#*]]
+
 ## Overview
 
-Create a blank worspace that will have [[multiple vaults|dendron.topic.multi-vault]]. , each of them serving different purposes and audiences. Some of all of this vaults can be independent git repositories that can be shared with others as you would with a regular git repo. The workspace, in turn, can also be a git repo itself.
+Create a blank worspace that will have [[multiple vaults|dendron.topic.multi-vault]], each of them serving different purposes and audiences. Some of them, or even all of them can be independent git repositories that can be shared with others as you would with a regular git repo. The workspace, in turn, can also be a git repo itself.
 
 ## Step by step
 
-### Start from scratch
-
 1. **Create a [[bare workspace|dendron.topic.workspace#concepts]]**. This workspace will be blank and contain all the needeed [[vaults|dendron.topic.vaults]] as well as the templates and configurations.
+   ![[dendron.topic.workspace#bare-workspace:#*]]
    1. Run `Dendron: Initialize Workspace` command.
    2. Type the location where you want it to be stored
    3. Select `blank`
-2. Add as many [[dendron.topic.vaults]] as needed, each one serving different purposes or audiences:
-   1. Create a local note for notes that will not be shared:
+2. Add as many [[dendron.topic.vaults]] as needed, each one serving different purposes or audiences.
+   
+   1. Create a **local note** for notes that will not be shared ([[more info here|dendron.topic.vaults#vault-add]]):
       1. Run `Dendron: Vault Add`
       2. Select `local`
       3. Type the location where you want it to be stored
       4. Type the name of the vault (can be different from the folder's name)
-   2. Add a remote vault for notes that will be shared (either with yourself or with others) you can either clone a remote note or create a local vault and then convert it into a remote one:
+   2. Add a **remote vault** for notes that will be shared (either with yourself or with others) you can either clone a remote note or create a local vault and then convert it into a remote one:
       1. Adding a remote vault: 
          1. Run `Dendron: Vault Add`
          2. Select `remote`
          3. Write the git location of the remote vault you want to clone
          4. The vault will be cloned inside your workspace
       2. Converting a local vault into a remote vault:
-         1. Run
-3. Write content
-   1. Make sure you add notes into the correspondent vault
-4. Syncronize notes by running `Dendron: Worskpace sync`
+         1. Run `Dendron: Convert Vault`
+         2. Select the name of your local vault that you want to convert
+         3. Select `Convert to remote vault`
+         4. Type the git location where you want to store your remote vault
+3. **Create notes** in the desired vault using the [[demo.lookup]] tool.
+   ![[dendron.topic.multi-vault#lookup:#prompt-for-vault-selection-each-time]]
+4. Synchronize notes by running `Dendron: Worskpace sync`
+   ![[dendron.topic.workspace#syncing-your-workspace-with-git]]
 
 
 

--- a/vault/dendron.guides.workflows.private-shared-setup.md
+++ b/vault/dendron.guides.workflows.private-shared-setup.md
@@ -16,7 +16,7 @@ Some specific use cases in which following a [[dendron.topic.multi-vault]] strat
 
 ## Overview
 
-Create a blank worspace that will have [[multiple vaults|dendron.topic.multi-vault]], each of them serving different purposes and audiences. Some of them, or even all of them can be independent git repositories that can be shared with others as you would with a regular git repo. The workspace, in turn, can also be a git repo itself.
+Create a blank worspace that will have [[multiple vaults|dendron.topic.multi-vault]], each serving different purposes and audiences. Each vault can be independent git repositories that can be shared with others as you would with a regular git repository. The workspace, itself, can also be a git repository.
 
 ## Step by step
 


### PR DESCRIPTION
Context: after [this discussion in discord](https://discord.com/channels/717965437182410783/917091167932383344/917129436250390619), I thought it could be a good idea to integrate @kevins8 's gist https://gist.github.com/kevinslin/0e0f13fedb43732e86938ab1033b7efd into a note within dendron.

I've created a new workflow guide which is not anything but a step-by-step use of a multi-vault strategy. Feel free to integrate if you can see value here or simply ignore it (it was useful for me, at least, as I learned how to do it by writing it).

