### PR TITLE
Add npx command to Preview Your Site page

### DIFF
--- a/vault/dendron.topic.publish-legacy.quickstart.preview-your-site.md
+++ b/vault/dendron.topic.publish-legacy.quickstart.preview-your-site.md
@@ -36,7 +36,7 @@ npm install @dendronhq/dendron-11ty-legacy@latest
 After you have your dependencies installed, build your site using the following command inside your workspace root.
 
 ```bash
-dendron buildSite  --stage dev --serve
+npx dendron buildSite  --stage dev --serve
 ```
 
 This will both compile your site locally and make it available at `localhost:8080` for instant preview. When building your site locally, the pages will be build to `{wsRoot}/build/site`. 
@@ -82,7 +82,7 @@ When your done, run the pre
 When you are ready to publish to github, make sure to change the stage to `prod`.
 
 ```bash
-dendron buildSite --stage prod 
+npx dendron buildSite --stage prod 
 ```
 
 This will build your site to the path specified by [[siteRootDir|dendron.topic.publish-legacy.configuration#siterootdir-required]] in `dendron.yml`.  By default, this is located at `{wsRoot}/docs`.


### PR DESCRIPTION
For people like me who have never used node before it was not clear that to call the dendron command you had to prefix it with npx, I only managed to find it after a lot of searching because an old issue had the command in with the npx prefix. It would be good if this page had the full command so it can just be copied to the terminal and ran within VSCode.