### PR TITLE
Initial changelog and release notes for 0.78

### DIFF
--- a/.brokignore
+++ b/.brokignore
@@ -19,3 +19,5 @@ https://support.airtable.com/hc/en-us/articles/219046777-How-do-I-get-my-API-key
 https://www.textasticapp.com/
 https://link.dendron.so
 https://dendron.memberful.com
+https://amar.io/memo
+https://theia-ide.org/

--- a/vault/changelog.md
+++ b/vault/changelog.md
@@ -2,10 +2,25 @@
 id: 9bc92432-a24c-492b-b831-4d5378c1692b
 title: Changelog
 desc: ''
-updated: 1641924279346
+updated: 1642485114942
 created: 1601508213606
 nav_order: 2
 ---
+
+## 0.78.0
+
+### Enhancements
+- enhance(pod): Markdown import pod avoids reformatting files ([[docs|dendron://dendron.dendron-site/dendron.topic.pod.builtin.markdown.import]]) (#2084) @kaan
+- enhance(workspace): `Dendron: Initialize Workspace` can use file picker to select destination, instead of typing it out ([[docs|dendron://dendron.dendron-site/dendron.ref.commands#initialize-workspace]]) (#2130) @tuling
+- enhance(markdown): allow notes to override the pretty refs setting ([[docs|dendron://dendron.dendron-site/dendron.topic.note-reference#configuration]]) (#2124) @kaan
+- enhance(workspace): detect config / client compatibility mismatch in cli (#2113) @hikchoi
+
+### Fix
+- fix(lookup): add sort by levenshtein distance prior to sorting by update date to lookup results of the same match score ([[docs|dendron://dendron.dendron-site/dendron.topic.lookup.find#sort-ordering]]) (#2111) @nickolay
+- fix(commands): paste-link-title-trim (#1961) [KamQb](https://github.com/KamQb) `@qKi#0849`
+- fix(workspace): insert note index enablement (#2133) @hikchoi
+- fix(views): hover preview containing local images on Windows (#2047) @kaan
+- fix(views): enable copy plaintext from preview (#2152) @kevin
 
 ## 0.77.0
 

--- a/vault/changelog.release.2022-01-18.md
+++ b/vault/changelog.release.2022-01-18.md
@@ -2,7 +2,7 @@
 id: 3UMZl74UsgY9by8BgbDDW
 title: '0.78'
 desc: ''
-updated: 1642518650025
+updated: 1642520832730
 created: 1642485037509
 ---
 
@@ -32,6 +32,7 @@ Lookup search results are leveling up when it comes to the displayed order of no
 #### General Updates
 
 - Discord: Starting this week, we'll be using an [[events|dendron://dendron.dendron-site/community.discord.channels#events]] stage channel for Dendron (such as _Office Hours_ and _New User Tuesdays_).
+- Discord: Use the new [[kudos|dendron://dendron.dendron-site/community.discord.channels#kudos]] channel to give recognition to other community members!
 - `awesome-dendron`: Do you know of VS Code extensions, note taking workflow links, and other resources you want to share with the Dendron community? [Contribute to the discussion about an awesome list](https://github.com/dendronhq/dendron/discussions/2118)!
 
 #### Starboard and TIL Highlights

--- a/vault/changelog.release.2022-01-18.md
+++ b/vault/changelog.release.2022-01-18.md
@@ -2,7 +2,7 @@
 id: 3UMZl74UsgY9by8BgbDDW
 title: '0.78'
 desc: ''
-updated: 1642486202604
+updated: 1642518650025
 created: 1642485037509
 ---
 
@@ -53,7 +53,7 @@ git clone --separate-git-dir=C:/Users/username/my_workspace/dendron-site-git/.gi
 
 This week's entry in the [[Dendron Reading Series|dendron://dendron.dendron-site/community.events.reading-series]].
 
-#todo
+![[16 - How to be spontaneous and grab some unexpected fun|dendron://dendron.dendron-site/community.events.reading-series.2022.01.18]]
 
 #### Office Hours and New User Tuesdays
 
@@ -68,7 +68,44 @@ This week's entry in the [[Dendron Reading Series|dendron://dendron.dendron-site
 A big **thanks** to the following gardeners that brought up issues, contributions, and fixes to this release :man_farmer: :woman_farmer: 
 Visit [[Discord Roles|dendron://dendron.dendron-site/community.discord.roles]] for more information.
 
-#todo
+- [Kamil](https://github.com/KamQb) `@qKi#0849`
+  - #role.horticulturalist
+  - [fix/paste-link-title-trim](https://github.com/dendronhq/dendron/pull/1961)
+
+- [Sahil](https://github.com/sahil48)
+  - #role.bugcatcher
+  - [Long Titles in Search Results Overflow in Full Text Search](https://github.com/dendronhq/dendron/issues/2127)
+  - [Search Bar Results to not stay anchored to the search bar when scrolling up](https://github.com/dendronhq/dendron/issues/2128)
+
+- [Jeff Hopper](https://github.com/HopperTech)
+  - [Search result link jumps to top of page](https://github.com/dendronhq/dendron/issues/2144)
+
+- [Adam Gluck](https://github.com/aglucky) `@glucinater21#0869`
+  - [Mobile Logo Issue](https://github.com/dendronhq/dendron/issues/2159)
+
+- [Tsvetomir Bonev](https://github.com/invakid404)
+  - #role.bugcatcher
+  - [logo url doesn't take assetsPrefix into account](https://github.com/dendronhq/dendron/issues/2161)
+
+- [Andrey Jef](https://github.com/andrey-jef) `@evanAndiez#9559`
+  - #role.bugcatcher
+  - [Inconsistent layout of mobile view of published pages](https://github.com/dendronhq/dendron/issues/2175)
+
+- [Jack](https://github.com/imalightbulb) `@I'm a lightbulb#6986`
+  - #role.bugcatcher
+  - [numbering with no text are squashed together in the preview](https://github.com/dendronhq/dendron/issues/2178)
+
+- [James Henry](https://github.com/henry-js) `@henry-js#6283`
+  - #role.bugcatcher
+  - [dendron-site: Troubleshooting `#lookup-shortcut-is-not-working`?](https://github.com/dendronhq/dendron-site/issues/357)
+
+- [Michael Harrison](https://github.com/micharris42) `@micharris42#6073`
+  - #role.taxonomist
+  - [dendron-site: Updates to the Extensions page on the Dendron Wiki](https://github.com/dendronhq/dendron-site/issues/359)
+
+- [Callum Mcdonald](https://github.com/chmac) `@chmac#2931`
+  - #role.horticulturalist
+  - [dendron-site: Minor typo fix](https://github.com/dendronhq/dendron-site/pull/365)
 
 ### Changelog
 ![[changelog#0780,1:#0770]]

--- a/vault/changelog.release.2022-01-18.md
+++ b/vault/changelog.release.2022-01-18.md
@@ -2,7 +2,7 @@
 id: 3UMZl74UsgY9by8BgbDDW
 title: '0.78'
 desc: ''
-updated: 1642486015886
+updated: 1642486202604
 created: 1642485037509
 ---
 
@@ -15,17 +15,17 @@ The Markdown Import Pod now imports markdown in a cleaner fashion without reform
 Lookup search results are leveling up when it comes to the displayed order of notes you may be looking for. For more information on these improvements, visit the docs on Lookup [[Sort Ordering|dendron://dendron.dendron-site/dendron.topic.lookup.find#sort-ordering]].
 
 ### Highlights
-- enhance(pod): Markdown import pod avoids reformatting files ([[docs|dendron://dendron.dendron-site/dendron.topic.pod.builtin.markdown.import]]) (#2084) @kaan
-- enhance(workspace): `Dendron: Initialize Workspace` can use file picker to select destination, instead of typing it out ([[docs|dendron://dendron.dendron-site/dendron.ref.commands#initialize-workspace]]) (#2130) @tuling
-- fix(lookup): add sort by levenshtein distance prior to sorting by update date to lookup results of the same match score ([[docs|dendron://dendron.dendron-site/dendron.topic.lookup.find#sort-ordering]]) (#2111) @nickolay
+- enhance(pod): Markdown import pod avoids reformatting files ([[docs|dendron://dendron.dendron-site/dendron.topic.pod.builtin.markdown.import]])
+- enhance(workspace): `Dendron: Initialize Workspace` can use file picker to select destination, instead of typing it out ([[docs|dendron://dendron.dendron-site/dendron.ref.commands#initialize-workspace]])
+- fix(lookup): add sort by levenshtein distance prior to sorting by update date to lookup results of the same match score ([[docs|dendron://dendron.dendron-site/dendron.topic.lookup.find#sort-ordering]])
 
 ### Everything Else
-- enhance(markdown): allow notes to override the pretty refs setting ([[docs|dendron://dendron.dendron-site/dendron.topic.note-reference#configuration]]) (#2124) @kaan
-- enhance(workspace): detect config / client compatibility mismatch in cli (#2113) @hikchoi
-- fix(commands): paste-link-title-trim (#1961) [KamQb](https://github.com/KamQb) `@qKi#0849`
-- fix(workspace): insert note index enablement (#2133) @hikchoi
-- fix(views): hover preview containing local images on Windows (#2047) @kaan
-- fix(views): enable copy plaintext from preview (#2152) @kevin
+- enhance(markdown): allow notes to override the pretty refs setting ([[docs|dendron://dendron.dendron-site/dendron.topic.note-reference#configuration]])
+- enhance(workspace): detect config / client compatibility mismatch in cli
+- fix(commands): paste-link-title-trim
+- fix(workspace): insert note index enablement
+- fix(views): hover preview containing local images on Windows
+- fix(views): enable copy plaintext from preview
 
 ### Community
 

--- a/vault/changelog.release.2022-01-18.md
+++ b/vault/changelog.release.2022-01-18.md
@@ -1,0 +1,74 @@
+---
+id: 3UMZl74UsgY9by8BgbDDW
+title: '0.78'
+desc: ''
+updated: 1642486015886
+created: 1642485037509
+---
+
+Dendron 0.78 has sprouted  🌱
+
+Initializing a new workspace has just become easier: `Dendron: Initialize Workspace` now provides a file explorer to navigate to a destination on your filesystem.
+
+The Markdown Import Pod now imports markdown in a cleaner fashion without reformatting the contents of the body. Only internal links to local files are now updated!
+
+Lookup search results are leveling up when it comes to the displayed order of notes you may be looking for. For more information on these improvements, visit the docs on Lookup [[Sort Ordering|dendron://dendron.dendron-site/dendron.topic.lookup.find#sort-ordering]].
+
+### Highlights
+- enhance(pod): Markdown import pod avoids reformatting files ([[docs|dendron://dendron.dendron-site/dendron.topic.pod.builtin.markdown.import]]) (#2084) @kaan
+- enhance(workspace): `Dendron: Initialize Workspace` can use file picker to select destination, instead of typing it out ([[docs|dendron://dendron.dendron-site/dendron.ref.commands#initialize-workspace]]) (#2130) @tuling
+- fix(lookup): add sort by levenshtein distance prior to sorting by update date to lookup results of the same match score ([[docs|dendron://dendron.dendron-site/dendron.topic.lookup.find#sort-ordering]]) (#2111) @nickolay
+
+### Everything Else
+- enhance(markdown): allow notes to override the pretty refs setting ([[docs|dendron://dendron.dendron-site/dendron.topic.note-reference#configuration]]) (#2124) @kaan
+- enhance(workspace): detect config / client compatibility mismatch in cli (#2113) @hikchoi
+- fix(commands): paste-link-title-trim (#1961) [KamQb](https://github.com/KamQb) `@qKi#0849`
+- fix(workspace): insert note index enablement (#2133) @hikchoi
+- fix(views): hover preview containing local images on Windows (#2047) @kaan
+- fix(views): enable copy plaintext from preview (#2152) @kevin
+
+### Community
+
+#### General Updates
+
+- Discord: Starting this week, we'll be using an [[events|dendron://dendron.dendron-site/community.discord.channels#events]] stage channel for Dendron (such as _Office Hours_ and _New User Tuesdays_).
+- `awesome-dendron`: Do you know of VS Code extensions, note taking workflow links, and other resources you want to share with the Dendron community? [Contribute to the discussion about an awesome list](https://github.com/dendronhq/dendron/discussions/2118)!
+
+#### Starboard and TIL Highlights
+> These are highlights from the [[Dendron Discord|dendron://dendron.dendron-site/community.discord.channels]] `#starboard` and `#today-i-learned` channels.
+
+⭐ `evanAndiez#9559` [shared some git-fu](https://discordapp.com/channels/717965437182410783/742532267058004098/931750095471394856) on how [`--separate-git-dir`](https://git-scm.com/docs/git-clone#Documentation/git-clone.txt---separate-git-dirltgitdirgt) can be used with `git clone` to have `.git` exist in a different directory:
+
+> _"...I can simply put the Dendron vault folder directly inside an Obsidian vault in iCloud Drive to enjoy the mobile experience of Dendron, without worrying that the heavy-weight `.next` folder or the sheer amount of files from the `.git` folder might break the iCloud sync."_
+
+```bash
+# Command
+git clone --separate-git-dir=<path-to-git-dir/.git> url-to-git-repo
+
+# Example
+git clone --separate-git-dir=C:/Users/username/my_workspace/dendron-site-git/.git url-to-git-repo
+```
+
+#### Dendron Reading Series
+
+This week's entry in the [[Dendron Reading Series|dendron://dendron.dendron-site/community.events.reading-series]].
+
+#todo
+
+#### Office Hours and New User Tuesdays
+
+- **Office Hours:** Visit the [[Office Hours page|dendron://dendron.dendron-site/community.events.office-hours]] for notes from previous sessions.
+    - [YouTube Playlist](https://link.dendron.so/6yPa)
+    - Next: [Wed, Jan 19, 9:00 AM - 9:30 AM PST](https://link.dendron.so/luma)
+- **New User Tuesdays:** Visit the [[New User Tuesdays page|dendron://dendron.dendron-site/community.events.new-user-tuesdays]] for notes from previous sessions.
+    - Next: [Tue, Jan 25, 8:30 AM - 9:00 AM PST](https://link.dendron.so/luma)
+
+#### Thank You's
+
+A big **thanks** to the following gardeners that brought up issues, contributions, and fixes to this release :man_farmer: :woman_farmer: 
+Visit [[Discord Roles|dendron://dendron.dendron-site/community.discord.roles]] for more information.
+
+#todo
+
+### Changelog
+![[changelog#0780,1:#0770]]

--- a/vault/community.discord.channels.md
+++ b/vault/community.discord.channels.md
@@ -2,7 +2,7 @@
 id: PIPLLg61HYfjK361B9Jm6
 title: Channels
 desc: ''
-updated: 1642485824445
+updated: 1642520721951
 created: 1640809094657
 ---
 
@@ -103,6 +103,16 @@ All about using Dendron: the channels under the **Community** category are a goo
 ### starboard
 
 If you feel more people need to see a particular message, then give it a star emoji reaction. When messages are given more than one star emoji, in the other public Dendron Discord channels, a bot shares them to this channel.
+
+### kudos
+
+Give recognition to gardeners that have helped you out!
+
+Example:
+
+```
+@{username}: what you appreciate them for
+```
 
 ### chat
 

--- a/vault/community.discord.channels.md
+++ b/vault/community.discord.channels.md
@@ -2,7 +2,7 @@
 id: PIPLLg61HYfjK361B9Jm6
 title: Channels
 desc: ''
-updated: 1641494792027
+updated: 1642485824445
 created: 1640809094657
 ---
 
@@ -108,15 +108,19 @@ If you feel more people need to see a particular message, then give it a star em
 
 General chat about all the things.
 
+### events
+
+This is a [Discord _stage_ channel](https://discord.com/stages). This channel is used for Dendron events such as [[dendron://dendron.dendron-site/community.events.office-hours]] and [[dendron://dendron.dendron-site/community.events.new-user-tuesdays]].
+
 ### teatime
 
-This text channel is used during events like [[dendron://dendron.dendron-site/community.events.office-hours]] and [[dendron://dendron.dendron-site/community.events.new-user-tuesdays]]. Voice chat is referenced in the `#teatime` _voice_ channel.
+This text channel is used during events like [[dendron://dendron.dendron-site/community.events.office-hours]] and [[dendron://dendron.dendron-site/community.events.new-user-tuesdays]]. Voice chat is referenced in the [[events|dendron://dendron.dendron-site/community.discord.channels#events]] _stage_ channel.
 
 You're free to discuss anything at all in the `#teatime` channel. To help, we encourage using the pinned [[dendron://dendron.dendron-site/community.events.reading-series]] read as a starting point.
 
 #### teatime voice channel
 
-This voice channel is used during events like [[dendron://dendron.dendron-site/community.events.office-hours]] and [[dendron://dendron.dendron-site/community.events.new-user-tuesdays]]. Text chat is referenced in the `#teatime` channel.
+Want to voice chat with your fellow dendronites? Jump in here. Text chat is referenced in the `#teatime` channel.
 
 ### academia
 

--- a/vault/community.events.reading-series.2022.01.18.md
+++ b/vault/community.events.reading-series.2022.01.18.md
@@ -1,0 +1,21 @@
+---
+id: MYREkkM37E7YWsxn8zXQE
+title: '16 - How to be spontaneous and grab some unexpected fun'
+desc: ''
+updated: 1642518495377
+created: 1642517646576
+---
+
+- ['Don't plan it, just go!': how to be spontaneous - and grab some unexpected fun](https://link.dendron.so/72cr)
+
+I'm an ultra-scheduler. My calendar dictates each day, each week. Prior to the pandemic, I was already scheduling many aspects of my life in order to achieve goals and regularly catch up with friends.
+
+There was room for spontaneity...but I have difficulty figuring out how to fit that into my schedule.
+
+> While we often think anticipation is half the fun, in 2016 researchers from two US universities found that people enjoyed activities more when they were impromptu. Scheduling a coffee break or a movie, for instance, made them feel “less free-flowing and more work-like”, wrote the authors.
+
+The pandemic certainly hasn't made this easier. The tips on taking breaks and going for walks remind me of pomodoro benefits, but there I am again: _I'm taking the breaks to be more efficient!_
+
+My extraverted friends are excellent at dropping in at random times with calls or messages, sometimes at just the right time when I could use a chat.
+
+Do you struggle with spontaneity? If so, how have you made room for it in your life?


### PR DESCRIPTION
- Initial changelog and release notes for 0.78
- Update to Discord Channels about `events` stage channel
- Also opened #367 due to failing URL links I am ignoring, while later following-up

> TODO: This PR is a draft of the changelog and release notes. Before it can be ready to merge, it needs:
> - [x] Community contribution information
> - [x] Dendron Reading Series