### PR TITLE
Release notes for 0.79, and new Dendrologists section

### DIFF
--- a/vault/changelog.md
+++ b/vault/changelog.md
@@ -2,10 +2,32 @@
 id: 9bc92432-a24c-492b-b831-4d5378c1692b
 title: Changelog
 desc: ''
-updated: 1642784456748
+updated: 1643077987599
 created: 1601508213606
 nav_order: 2
 ---
+
+## 0.79.0
+
+### Breaking changes
+
+Since we are disabling [[date variable substitution|dendron://dendron.dendron-site/dendron.topic.templates#template-variables]], current users will not be able to use it for the time being.
+
+### Enhancements
+- enhance(publish): logo can reference a full URL path to external image ([[docs|dendron://dendron.dendron-site/dendron.topic.publish.faq#how-do-i-add-a-logo-to-my-website]]) (#2189) @kaan
+- enhance(lookup): add configuration for vault selection behavior with new `vaultSelectionModeOnCreate` config option, and change `confirmVaultOnCreate` default to `true` ([[docs|dendron://dendron.dendron-site/dendron.ref.config.commands#vaultselectionmodeoncreate]]) (#1960) @nickolay
+- enhance(publish): attempt to update Next.js template in-place (#2162) [Luke Carrier](https://github.com/LukeCarrier) `lukecarrier#2081`
+- enhance(publish): add lockfile to Next.js (#2215) @kevin
+
+### Fix
+- fix(server): highlighting breaks when there's too much text (#2163) @kaan
+- fix(workspace): stop link candidate logic when disabled (#2136) @hikchoi
+- fix(commands): renamed command from `Goto Note` to `Go to Note` (#2187) [skfile](https://github.com/skfile)
+- fix(markdown): Exclude parenthesis from tags (#2182) [Nicklas Gummesson](https://github.com/viddo) `viddo#9229`
+- fix(publish): logo doesn't respect `assetsPrefix` (#2189) @kaan
+- fix(workspace): cursor moves to top when opening file through the search (#2193) @kaan
+- fix(schema): Use string replace instead of lodash for date variable substitution (breaking change)
+- fix(publish): some published pages will show error (#2199) @kaan
 
 ## 0.78.0
 

--- a/vault/changelog.release.2022-01-25.md
+++ b/vault/changelog.release.2022-01-25.md
@@ -1,0 +1,71 @@
+---
+id: 2O1bIbvJ7w1NkO7OyvSys
+title: '0.79'
+desc: ''
+updated: 1643078003836
+created: 1643076020482
+---
+
+Dendron 0.79 has sprouted  🌱
+
+Are you interested in using a logo for your website without needing to include it in the local repository? Now you can publish by referencing a URL (`https://example.com/logo.png`) in your `dendron.yml` configs.
+
+When creating new notes, in multi-vault workspaces, `confirmVaultOnCreate` now defaults to `true`. We've added another config option where you can have Dendron _always_ prompt where a new note should exist with `vaultSelectionModeOnCreate`.
+
+Breaking change: A fix in this release will disable [date variable substitution](https://wiki.dendron.so/notes/861cbdf8-102e-4633-9933-1f3d74df53d2.html#template-variables), so current users will not be able to use it for the time being.
+
+### Highlights
+- enhance(publish): logo can reference a full URL path to external image ([[docs|dendron://dendron.dendron-site/dendron.topic.publish.faq#how-do-i-add-a-logo-to-my-website]]) 
+- enhance(lookup): add configuration for vault selection behavior with new `vaultSelectionModeOnCreate` config option, and change `confirmVaultOnCreate` default to `true` ([[docs|dendron://dendron.dendron-site/dendron.ref.config.commands#vaultselectionmodeoncreate]])
+- enhance(publish): attempt to update Next.js template in-place
+- enhance(publish): add lockfile to Next.js
+
+### Everything Else
+- fix(server): highlighting breaks when there's too much text
+- fix(workspace): stop link candidate logic when disabled
+- fix(commands): renamed command from `Goto Note` to `Go to Note`
+- fix(markdown): Exclude parenthesis from tags
+- fix(publish): logo doesn't respect assetsPrefix
+- fix(workspace): cursor moves to top when opening file through the search
+- fix(schema): Use string replace instead of lodash for date variable substitution (breaking change)
+- fix(publish): some published pages will show error
+
+### Community
+
+#### Announcing our Dendrologists
+
+
+
+#### Starboard and TIL Highlights
+<!-- TODO: update links. Delete section is no new items-->
+> These are highlights from the [[Dendron Discord|dendron://dendron.dendron-site/community.discord.channels]] `#starboard` and `#today-i-learned` channels.
+
+- ⭐ `viddo#9229` shared a link to [a Tweet about new VS Code insider features](https://twitter.com/mattbierner/status/1483590058066149376): _The latest VS Code insiders adds completions for Markdown links, including: path/file links, header links, and reference links_
+- ⭐ `hrmck#7968` learned how you can [[Add Dendron to application launchers on Linux desktops|dendron://dendron.dendron-site/dendron.guides.cook#add-dendron-to-application-launchers-on-linux-desktops]]
+- ⭐ `lukecarrier#2081` showed [how he used Gource](https://gist.github.com/LukeCarrier/debd81f1a83e4442ade71434ee36dd04) to create a video of his [Dendron Second Brain growing over time](https://www.youtube.com/watch?v=CD9xCoknhyU): _"I figured it'd be interesting running [Gource](https://gource.io/) over my Dendron workspace to show its growth since I went all in with it around a year ago"_
+- 💡 `krisfremen#6757` wondered if Dendron was hiring: [[the answer is yes!|dendron://dendron.dendron-site/careers]]
+- 💡 `moksha#0720` learned about [[schemas and templates|dendron://dendron.dendron-site/dendron.topic.schema.tutorial.first-schema]], and now uses them for [interstitial journaling](https://nesslabs.com/interstitial-journaling) within Dendron
+- 💡 `Jack of some quantity of trades#3247` said: _"TIL about the existence of [cooklang](https://cooklang.org/), a markup language + cli tool + webserver setup for recipe/grocery management"_
+- 💡 `Jack of some quantity of trades#3247` said: _"TIL about the [Final Version Perfected algorithm](https://www.lesswrong.com/posts/xfcKYznQ6B9yuxB28/final-version-perfected-an-underused-execution-algorithm) for exhaustively and efficiently prioritizing tasks on any itemized to-do list under most conditions"_
+
+#### Dendron Reading Series
+
+This week's entry in the [[Dendron Reading Series|dendron://dendron.dendron-site/community.events.reading-series]].
+
+#### Office Hours and New User Tuesdays
+
+- **Office Hours:** Visit the [[Office Hours page|dendron://dendron.dendron-site/community.events.office-hours]] for notes from previous sessions.
+    - [YouTube Playlist](https://link.dendron.so/6yPa)
+    - Next: [Wed, Feb 02, 9:00 AM - 9:30 AM PST](https://link.dendron.so/luma)
+- **New User Tuesdays:** Visit the [[New User Tuesdays page|dendron://dendron.dendron-site/community.events.new-user-tuesdays]] for notes from previous sessions.
+    - Next: [Tue, Feb 08, 8:30 AM - 9:00 AM PST](https://link.dendron.so/luma)
+
+#### Thank You's
+
+A big **thanks** to the following gardeners that brought up issues, contributions, and fixes to this release :man_farmer: :woman_farmer: 
+Visit [[Discord Roles|dendron://dendron.dendron-site/community.discord.roles]] for more information.
+
+#todo
+
+### Changelog
+![[changelog#0790,1:#0780]]

--- a/vault/changelog.release.2022-01-25.md
+++ b/vault/changelog.release.2022-01-25.md
@@ -2,7 +2,7 @@
 id: 2O1bIbvJ7w1NkO7OyvSys
 title: '0.79'
 desc: ''
-updated: 1643078003836
+updated: 1643088536760
 created: 1643076020482
 ---
 
@@ -34,10 +34,12 @@ Breaking change: A fix in this release will disable [date variable substitution]
 
 #### Announcing our Dendrologists
 
+We'd love to introduce the Dendron community to our new [[Dendrologists|dendron://dendron.dendron-site/community.dendrologists]]! They'll be focusing on growing and fostering the Dendron community by covering key [[focus areas|dendron://dendron.dendron-site/community.dendrologists]] such as contributor experience, coordinating community events, improving the docs, and maintaining community gardens.
 
+![[community.dendrologists#meet-the-dendrologists,1:#*]]
 
 #### Starboard and TIL Highlights
-<!-- TODO: update links. Delete section is no new items-->
+
 > These are highlights from the [[Dendron Discord|dendron://dendron.dendron-site/community.discord.channels]] `#starboard` and `#today-i-learned` channels.
 
 - ⭐ `viddo#9229` shared a link to [a Tweet about new VS Code insider features](https://twitter.com/mattbierner/status/1483590058066149376): _The latest VS Code insiders adds completions for Markdown links, including: path/file links, header links, and reference links_
@@ -51,6 +53,8 @@ Breaking change: A fix in this release will disable [date variable substitution]
 #### Dendron Reading Series
 
 This week's entry in the [[Dendron Reading Series|dendron://dendron.dendron-site/community.events.reading-series]].
+
+#todo
 
 #### Office Hours and New User Tuesdays
 

--- a/vault/community.dendrologists.md
+++ b/vault/community.dendrologists.md
@@ -2,13 +2,13 @@
 id: 0QQNklzyOweaOez8E7iTX
 title: Dendrologists
 desc: ''
-updated: 1643087824949
+updated: 1643087950830
 created: 1643087178878
 ---
 
 ## Summary
 
-Dendrologists are community members that help foster, grow, and nurture our growing community.
+Dendrologists are community moderators that help foster, grow, and nurture our growing community.
 
 ## Details
 

--- a/vault/community.dendrologists.md
+++ b/vault/community.dendrologists.md
@@ -1,0 +1,61 @@
+---
+id: 0QQNklzyOweaOez8E7iTX
+title: Dendrologists
+desc: ''
+updated: 1643087824949
+created: 1643087178878
+---
+
+## Summary
+
+Dendrologists are community members that help foster, grow, and nurture our growing community.
+
+## Details
+
+The Dendron [[community|dendron://dendron.dendron-site/community]] has more than 1k members, and is continuing to grow. 
+
+Since first sprouting, Dendron has focused on creating a welcoming space for users interested in knowledge management to come together, connect, and learn from one another.
+Something that we take a great effort to do is personally greet each new user, help them connect with others, and make sure that their questions are being addressed.
+
+To scale out this process for the next 1k users (and beyond), we've looked for help from the community to help keep our space one where curious minds can thrive. 
+
+## Meet the Dendrologists
+
+<iframe class="airtable-embed" src="https://airtable.com/embed/shrVE68b6WIA6xkjA?backgroundColor=purple&viewControls=on" frameborder="0" onmousewheel="" width="100%" height="533" style="background: transparent; border: 1px solid #ccc;"></iframe>
+
+## Focus Areas
+
+The following are specific focus areas that a Dendrologist can choose to lead. 
+
+### Members and Guidelines
+
+> We need help from the community, as we currently don't have a Dendrologist in this focus! Feel free to reach out to a Dendron team member, or Dendrologist, in the community [[Discord|dendron://dendron.dendron-site/community.discord]] for more information.
+
+Help come up with guidelines for conduct and discussion. Find new ways of recognizing outstanding members (eg. swag, roles, starboard, etc) and contributions. 
+
+### Events
+
+Help coordinate Dendron community [[events|dendron://dendron.dendron-site/community.events]].
+A big focus for this year is restarting the [[Greenhouse Talks|dendron://dendron.dendron-site/community.events.greenhouse]] with speakers from both the team as well as the community. 
+
+### Issues
+
+Be the voice of the community and relay asks from other Dendronites. Pick out tasks for [[CROP|dendron://dendron.dendron-site/community.events.crop]].
+
+### Docs
+
+Help us ensure that documentation is consistent and that insight in discord threads are recorded so that wisdom can be preserved for future generations.
+
+### Contributors
+
+Help new people contribute to the Dendron code base. Raise awareness of [good first tasks](https://github.com/dendronhq/dendron/labels/size.small) and make proposals to get more folks involved.
+Note that contributions are not just limited to code but could also be doc-related or graphic related.
+
+### Garden Stewards
+
+Be the maintainer of a community garden. The current one we have is https://pkm.dendron.so/.
+We will be looking to add a few more before this year is done
+
+## Related
+
+- [RFC 39 - Dendrologists](https://docs.dendron.so/notes/kN01TwMOtGjaewNnm8QHW/)


### PR DESCRIPTION
## What

- Release notes and changelog for 0.79
- New Dendrologists docs. Much of the content was pulled from the [RFC 39 - Dendrologists](https://docs.dendron.so/notes/kN01TwMOtGjaewNnm8QHW/) documentation

## To Do

> This is a PR that needs to be reviewed, and needs to final sections completed

- [ ] Dendron Reading Series
- [ ] Contributor recognition section of release notes