### PR TITLE
Fix a few small typos

### DIFF
--- a/vault/dendron._ref.status.md
+++ b/vault/dendron._ref.status.md
@@ -23,7 +23,7 @@ Sometimes, you'll see a `status` underneath certain features or options. This pa
 
 ### Early Seed 🌱
 
-The feature or option was recently added and might only be available in Dendron's [[early seed release|dendron.concepts#early-seed-release]]. Early seed features are considured beta and may change at any time.
+The feature or option was recently added and might only be available in Dendron's [[early seed release|dendron.concepts#early-seed-release]]. Early seed features are considered beta and may change at any time.
 
 ### Experimental 🧪 
 

--- a/vault/dendron.concepts.md
+++ b/vault/dendron.concepts.md
@@ -126,7 +126,7 @@ Glob patterns are a way of pattern matching characters. You can test and see mor
 
 ### Early Seed Release
 
-Early builds of Dendron. Only availble to [[Environmentalist|community.discord.roles#environmentalist]].
+Early builds of Dendron. Only available to [[Environmentalist|community.discord.roles#environmentalist]].
 
 ### Slug
 


### PR DESCRIPTION
This PR is simply fixing some typos that I found while browsing the dendron documentation.