### PR TITLE
Deprecation notice on legacy publishing notes

### DIFF
--- a/vault/dendron.topic.publish-legacy.advanced.md
+++ b/vault/dendron.topic.publish-legacy.advanced.md
@@ -2,9 +2,12 @@
 id: e9f26a4b-ddce-41b3-9619-8f4f64761f86
 title: Advanced
 desc: ''
-updated: 1640428477249
+updated: 1645121261657
 created: 1600564193281
 ---
+
+![[dendron://dendron.dendron-site/dendron.topic.publish-legacy#deprecated,1]]
+
 ### Exclude from publication
 
 To exclude a page from publication, you can add the following to the frontmatter. If you set `publishByDefault: false` for a hierarchy, this needs to be set to `true` to publish

--- a/vault/dendron.topic.publish-legacy.blogging.md
+++ b/vault/dendron.topic.publish-legacy.blogging.md
@@ -2,10 +2,11 @@
 id: 6d21fd60-e564-4a55-b4c0-d2586293b908
 title: Blogging
 desc: ''
-updated: 1614547898424
+updated: 1645121306842
 created: 1614547017272
 ---
 
+![[dendron://dendron.dendron-site/dendron.topic.publish-legacy#deprecated,1]]
 
 You can use Dendron for blogging. To do so, add [[collection specific options|dendron.topic.publish-legacy.configuration#collection-options]] to your frontmatter. 
 

--- a/vault/dendron.topic.publish-legacy.changelogs.md
+++ b/vault/dendron.topic.publish-legacy.changelogs.md
@@ -2,9 +2,11 @@
 id: e1b84d7e-9b0d-4616-917f-f3af1e7541b0
 title: Changelogs
 desc: ''
-updated: 1640425016997
+updated: 1645121270673
 created: 1615241095799
 ---
+
+![[dendron://dendron.dendron-site/dendron.topic.publish-legacy#deprecated,1]]
 
 ## Summary
 - status: 🚧

--- a/vault/dendron.topic.publish-legacy.collections.md
+++ b/vault/dendron.topic.publish-legacy.collections.md
@@ -2,9 +2,12 @@
 id: e4ea4fe3-0350-492e-863a-687d9fc15993
 title: Collections
 desc: ''
-updated: 1614538231995
+updated: 1645121293427
 created: 1609433737726
 ---
+
+![[dendron://dendron.dendron-site/dendron.topic.publish-legacy#deprecated,1]]
+
 Sometimes, you might want to publish a page that has all its children listed like in a blog archive format. 
 
 ![](https://foundation-prod-assetspublic53c57cce-8cpvgjldwysl.s3-us-west-2.amazonaws.com/assets/images/publishv2.collection.jpg)

--- a/vault/dendron.topic.publish-legacy.cook.md
+++ b/vault/dendron.topic.publish-legacy.cook.md
@@ -2,10 +2,11 @@
 id: 1d9c4d11-1536-449b-af6b-a4a1acb203e4
 title: Cook
 desc: ''
-updated: 1611351277601
+updated: 1645120327322
 created: 1611351130281
 ---
 
+![[dendron://dendron.dendron-site/dendron.topic.publish-legacy#deprecated,1]]
 
 ### Publishing on Vercel
 

--- a/vault/dendron.topic.publish-legacy.faq.md
+++ b/vault/dendron.topic.publish-legacy.faq.md
@@ -2,9 +2,12 @@
 id: 5a529992-0c62-4291-81df-550638f06a46
 title: FAQ
 desc: ''
-updated: 1640425973203
+updated: 1645120246042
 created: 1609883599513
 ---
+
+![[dendron://dendron.dendron-site/dendron.topic.publish-legacy#deprecated,1]]
+
 ### Why am I taken to a 403 page?
 
 Dendron will auto-generate 403 pages during publication when a published note links to notes that are not published. You can see [[here|dendron.topic.publish-legacy.selective-publication]] for configuration behind selective publication.

--- a/vault/dendron.topic.publish-legacy.features.md
+++ b/vault/dendron.topic.publish-legacy.features.md
@@ -2,10 +2,12 @@
 id: 2fe96d3a-dcf9-409b-8a09-fdaa5a664433
 title: Features
 desc: ''
-updated: 1640368764334
+updated: 1645121253522
 created: 1608528227846
 nav_order: 1
 ---
+
+![[dendron://dendron.dendron-site/dendron.topic.publish-legacy#deprecated,1]]
 
 ### Nested Hierarchies
 

--- a/vault/dendron.topic.publish-legacy.github.md
+++ b/vault/dendron.topic.publish-legacy.github.md
@@ -2,9 +2,11 @@
 id: 877f4347-f013-43ba-aec4-87412b2e1bec
 title: GitHub
 desc: ''
-updated: 1640426006522
+updated: 1645121080086
 created: 1608770937168
 ---
+
+![[dendron://dendron.dendron-site/dendron.topic.publish-legacy#deprecated,1]]
 
 This guide describes publishing to GitHub using GitHub Actions
 

--- a/vault/dendron.topic.publish-legacy.md
+++ b/vault/dendron.topic.publish-legacy.md
@@ -2,8 +2,11 @@
 id: PE105RwXAoJiAWU6fNjOx
 title: Publish Legacy
 desc: ''
-updated: 1635379320905
+updated: 1645120234743
 created: 1635379320905
-stub: true
+stub: false
 ---
 
+## Deprecated
+
+> **DEPRECATION NOTICE:** This is documentation related to legacy publishing. For the latest guidance, reference the [[current publishing documentation|dendron://dendron.dendron-site/dendron.topic.publish]].

--- a/vault/dendron.topic.publish-legacy.migration.md
+++ b/vault/dendron.topic.publish-legacy.migration.md
@@ -2,9 +2,12 @@
 id: fd26b3ef-7978-41c9-8f45-4c4f8414951d
 title: Migration
 desc: ''
-updated: 1630794922064
+updated: 1645121282832
 created: 1608528487798
 ---
+
+![[dendron://dendron.dendron-site/dendron.topic.publish-legacy#deprecated,1]]
+
 All values that used to be written into `_config.yml` will now be moved into `dendron.yml`. You can see the currently supported configuration values here: `https://github.com/dendronhq/dendron/blob/master/packages/common-all/src/types/typesv2.ts`
 
 If you currently have a Jekyll based Dendron page, note that the following settings have changed:

--- a/vault/dendron.topic.publish-legacy.misc.md
+++ b/vault/dendron.topic.publish-legacy.misc.md
@@ -2,10 +2,11 @@
 id: 491cafdd-d4bf-4c6a-9f95-532af4666828
 title: Misc
 desc: ''
-updated: 1614630219483
+updated: 1645120255394
 created: 1614630136994
 ---
 
+![[dendron://dendron.dendron-site/dendron.topic.publish-legacy#deprecated,1]]
 
 ## Markdown Differences
 

--- a/vault/dendron.topic.publish-legacy.multi-vault.md
+++ b/vault/dendron.topic.publish-legacy.multi-vault.md
@@ -2,11 +2,12 @@
 id: 4ab1ce1c-3ab5-4d2a-a4b0-ddfcc4d64343
 title: Multi Vault
 desc: ''
-updated: 1610166729889
+updated: 1645121329691
 created: 1610166683840
 published: false
 ---
 
+![[dendron://dendron.dendron-site/dendron.topic.publish-legacy#deprecated,1]]
 
 There are some additional factors that come into play when dealing with multiple vaults.
 

--- a/vault/dendron.topic.publish-legacy.navigation.md
+++ b/vault/dendron.topic.publish-legacy.navigation.md
@@ -2,9 +2,12 @@
 id: 5f23182f-2936-4790-8d04-00bd502df723
 title: Navigation
 desc: ''
-updated: 1627941717046
+updated: 1645121300759
 created: 1609563320271
 ---
+
+![[dendron://dendron.dendron-site/dendron.topic.publish-legacy#deprecated,1]]
+
 Dendron has two navigation sections: the nav bar on the left and the table of contents on the bottom of each note. 
 
 ![publishing](https://foundation-prod-assetspublic53c57cce-8cpvgjldwysl.s3-us-west-2.amazonaws.com/assets/images/publishv2.nav.jpg)

--- a/vault/dendron.topic.publish-legacy.quickstart.md
+++ b/vault/dendron.topic.publish-legacy.quickstart.md
@@ -2,10 +2,12 @@
 id: 861e4e48-dcc5-4813-a695-8940ba6e64d3
 title: Quickstart
 desc: ''
-updated: 1615522508758
+updated: 1645121394824
 created: 1608528402469
 nav_order: 2
 ---
+
+![[dendron://dendron.dendron-site/dendron.topic.publish-legacy#deprecated,1]]
 
 NOTE: it's possible to publish Dendron on any platform that can host static sites. This guide covers publishing to [GitHub Pages](https://pages.github.com/)
 

--- a/vault/dendron.topic.publish-legacy.quickstart.preview-your-site.md
+++ b/vault/dendron.topic.publish-legacy.quickstart.preview-your-site.md
@@ -2,11 +2,12 @@
 id: 1399b5d2-28fb-4077-aa5f-c8edbe52bc5d
 title: Preview Your Site
 desc: ''
-updated: 1631833327494
+updated: 1645121384307
 created: 1610844309611
 nav_order: 1
 ---
 
+![[dendron://dendron.dendron-site/dendron.topic.publish-legacy#deprecated,1]]
 
 ## CLI
 

--- a/vault/dendron.topic.publish-legacy.quickstart.publishing-your-site.md
+++ b/vault/dendron.topic.publish-legacy.quickstart.publishing-your-site.md
@@ -2,9 +2,11 @@
 id: 230d0ccf-5758-4a8f-b39b-3b68e1482e2b
 title: Publishing Your Site
 desc: ''
-updated: 1640383346817
+updated: 1645121389818
 created: 1610844337503
 ---
+
+![[dendron://dendron.dendron-site/dendron.topic.publish-legacy#deprecated,1]]
 
 ## VS Code
 

--- a/vault/dendron.topic.publish-legacy.selective-publication.md
+++ b/vault/dendron.topic.publish-legacy.selective-publication.md
@@ -2,9 +2,12 @@
 id: c93938a4-0938-49d0-aca2-00e624793650
 title: Selective Publication
 desc: ''
-updated: 1613873980711
+updated: 1645121344371
 created: 1609883716869
 ---
+
+![[dendron://dendron.dendron-site/dendron.topic.publish-legacy#deprecated,1]]
+
 In Dendron, you control what gets published. 
 
 ![[dendron.topic.publish-legacy.configuration#summary,1:#*]]

--- a/vault/dendron.topic.publish-legacy.troubleshooting.md
+++ b/vault/dendron.topic.publish-legacy.troubleshooting.md
@@ -2,9 +2,11 @@
 id: 5ca2fe99-0abc-413d-aa06-50f9a66e13e0
 title: Troubleshooting
 desc: ''
-updated: 1623863531700
+updated: 1645121320515
 created: 1609525003662
 ---
+
+![[dendron://dendron.dendron-site/dendron.topic.publish-legacy#deprecated,1]]
 
 ## Diagnostics
 


### PR DESCRIPTION
Add deprecation notice to legacy documents, as users have reported accidentally following the Legacy docs directions before realizing they weren't looking at the latest.