### PR TITLE
Update dendron.ref.topics.md

### DIFF
--- a/vault/dendron.ref.topics.md
+++ b/vault/dendron.ref.topics.md
@@ -31,6 +31,7 @@ This is a reference of all Dendron topics (features), sorted alphabetically. For
 - [[Pods|dendron://dendron.dendron-site/dendron.topic.pod]]
 - [[Preview|dendron://dendron.dendron-site/dendron.topic.preview]]
 - [[Publish|dendron://dendron.dendron-site/dendron.topic.publish]]
+- [[Publish|dendron://dendron.dendron-site/dendron.topic.refactoring]]
 - [[Schemas|dendron://dendron.dendron-site/dendron.topic.schema]]
 - [[Search|dendron://dendron.dendron-site/dendron.topic.search]]
 - [[Special Notes|dendron://dendron.dendron-site/dendron.topic.special-notes]]

--- a/vault/dendron.ref.topics.md
+++ b/vault/dendron.ref.topics.md
@@ -31,7 +31,7 @@ This is a reference of all Dendron topics (features), sorted alphabetically. For
 - [[Pods|dendron://dendron.dendron-site/dendron.topic.pod]]
 - [[Preview|dendron://dendron.dendron-site/dendron.topic.preview]]
 - [[Publish|dendron://dendron.dendron-site/dendron.topic.publish]]
-- [[Publish|dendron://dendron.dendron-site/dendron.topic.refactoring]]
+- [[Refactoring|dendron://dendron.dendron-site/dendron.topic.refactoring]]
 - [[Schemas|dendron://dendron.dendron-site/dendron.topic.schema]]
 - [[Search|dendron://dendron.dendron-site/dendron.topic.search]]
 - [[Special Notes|dendron://dendron.dendron-site/dendron.topic.special-notes]]


### PR DESCRIPTION
Add "Refactoring" to the Topics list.  Page exists but no link in the Topics list.  Refactoring:  https://wiki.dendron.so/notes/srajljj10V2dl19nCSFiC/