### PR TITLE
Release notes, changelog, and reading series for 0.83

### DIFF
--- a/vault/changelog.md
+++ b/vault/changelog.md
@@ -2,7 +2,7 @@
 id: 9bc92432-a24c-492b-b831-4d5378c1692b
 title: Changelog
 desc: ''
-updated: 1645493875831
+updated: 1645544640720
 created: 1601508213606
 nav_order: 2
 ---
@@ -11,11 +11,19 @@ nav_order: 2
 
 ### Breaking changes
 
-- The latest release of Dendron will prompt users to automatically migrate their `dendron.yml` configurations to use the latest publishing configuration. This update is not backwards compatible, meaning that updated workspace configurations won't work with older versions of `dendron-cli` used for publishing.
-  - Optionally, users can migrate their configurations via `dendron-cli`
-  ```sh
-  dendron dev run_migration --migrationVersion 0.83.0
-  ```
+The latest release of Dendron will prompt users to automatically migrate their `dendron.yml` configurations to use the latest publishing configuration. **This update is not backwards compatible**, meaning that updated workspace configurations (`version: 5`) won't work with older versions of `dendron-cli` used for publishing.
+
+If `dendron-cli` is not updated, you will encounter the following error message:
+
+```
+Cannot find minimum compatible client version. This error should never occur! Please report a bug if you have encountered this.
+```
+
+If running the latest `dendron-cli`, users can optionally migrate their configurations directly from `dendron-cli`:
+
+```sh
+dendron dev run_migration --migrationVersion 0.83.0
+```
 
 ### Deprecation Notices
 

--- a/vault/changelog.md
+++ b/vault/changelog.md
@@ -2,10 +2,25 @@
 id: 9bc92432-a24c-492b-b831-4d5378c1692b
 title: Changelog
 desc: ''
-updated: 1644943670603
+updated: 1645488376404
 created: 1601508213606
 nav_order: 2
 ---
+
+## 0.83.0
+
+### Enhancements
+- enhance(pods): add vault filter for pods-v2 hierarchy export ([[docs|dendron://dendron.dendron-site/dendron.topic.pod-v2.config#exportscope]]) (#2419) @joshi
+- enhance(notes): change dendron id format to be alphanumeric lowercase ([[docs|dendron://dendron.dendron-site/dendron.topic.frontmatter#id]]) (#2403) @kevin
+- enhance(workspace): Block Anchor support for non-note files ([[docs|dendron://dendron.dendron-site/dendron.topic.links#file-links]]) (#2377) @kaan
+- enhance(workspace): calculate backlinks and anchors in engine for improved editor responsiveness (#2389) @kaan
+
+### Fix
+- fix(workspace): Journal Note Consistency with Title and Traits (#2401) @jonathan
+- fix(workspace): Dendron will try to parse non-dendron files in `onFirstOpen` (#2405) @kevin
+- fix(workspace): error message to be readable in error toast (#2426) @joshi
+- fix(publish): horizontal line's height in publishing (#2441) @kaan
+- fix(publish): properly set siteIndex when it's not explicitly set by config (#2443) @hikchoi
 
 ## 0.82.0
 

--- a/vault/changelog.md
+++ b/vault/changelog.md
@@ -2,12 +2,26 @@
 id: 9bc92432-a24c-492b-b831-4d5378c1692b
 title: Changelog
 desc: ''
-updated: 1645488376404
+updated: 1645493875831
 created: 1601508213606
 nav_order: 2
 ---
 
 ## 0.83.0
+
+### Breaking changes
+
+- The latest release of Dendron will prompt users to automatically migrate their `dendron.yml` configurations to use the latest publishing configuration. This update is not backwards compatible, meaning that updated workspace configurations won't work with older versions of `dendron-cli` used for publishing.
+  - Optionally, users can migrate their configurations via `dendron-cli`
+  ```sh
+  dendron dev run_migration --migrationVersion 0.83.0
+  ```
+
+### Deprecation Notices
+
+- deprecate(publishing): Legacy publishing has now been removed from `dendron-cli`. Dendron users that haven't yet migrated from `dendron buildSite` commands must migrate to using the `dendron publish` commands.
+  - [[Common commands for Next.js publishing with dendron-cli|dendron://dendron.dendron-site/dendron.topic.publish.cook.common]]
+  - [[Upgrade Instructions|dendron://dendron.dendron-site/dendron.topic.publish.migration]]
 
 ### Enhancements
 - enhance(pods): add vault filter for pods-v2 hierarchy export ([[docs|dendron://dendron.dendron-site/dendron.topic.pod-v2.config#exportscope]]) (#2419) @joshi

--- a/vault/changelog.md
+++ b/vault/changelog.md
@@ -2,7 +2,7 @@
 id: 9bc92432-a24c-492b-b831-4d5378c1692b
 title: Changelog
 desc: ''
-updated: 1645544640720
+updated: 1645551755948
 created: 1601508213606
 nav_order: 2
 ---
@@ -11,7 +11,7 @@ nav_order: 2
 
 ### Breaking changes
 
-The latest release of Dendron will prompt users to automatically migrate their `dendron.yml` configurations to use the latest publishing configuration. **This update is not backwards compatible**, meaning that updated workspace configurations (`version: 5`) won't work with older versions of `dendron-cli` used for publishing.
+The latest release of Dendron will prompt users to automatically migrate their `dendron.yml` configurations to use the latest publishing configuration. Updated workspace configurations (`version: 5`) won't work with older versions of `dendron-cli`.
 
 If `dendron-cli` is not updated, you will encounter the following error message:
 
@@ -38,7 +38,7 @@ dendron dev run_migration --migrationVersion 0.83.0
 - enhance(workspace): calculate backlinks and anchors in engine for improved editor responsiveness (#2389) @kaan
 
 ### Fix
-- fix(workspace): Journal Note Consistency with Title and Traits (#2401) @jonathan
+- fix(workspace): Fixed instances where Journal note `title` values weren't properly formatted as `yyyy-MM-dd` and the `traitID` of `journalNote` wasn't being applied (#2401) @jonathan
 - fix(workspace): Dendron will try to parse non-dendron files in `onFirstOpen` (#2405) @kevin
 - fix(workspace): error message to be readable in error toast (#2426) @joshi
 - fix(publish): horizontal line's height in publishing (#2441) @kaan

--- a/vault/changelog.release.2022-02-22.md
+++ b/vault/changelog.release.2022-02-22.md
@@ -2,11 +2,15 @@
 id: ixhyxsx79zqjy25s7q9liud
 title: '0.83'
 desc: ''
-updated: 1645493265012
+updated: 1645493812159
 created: 1645488383028
 ---
 
 Dendron 0.83 has sprouted  🌱
+
+**Breaking changes:** This release of Dendron updates the publishing configuration within `dendron.yml`. This update is not backwards compatible, meaning that older versions of `dendron-cli` will not be able to publish a migrated workspace.
+
+- More information: [[0.83 Changelog|dendron://dendron.dendron-site/changelog.release.2022-02-22#changelog]].
 
 Pod V2 preview continues to grow: you can now export the contents of a hierarchy, filtered by a target vault. This means the multi-vault workspaces can be more targeted in their exports without including notes from undesired vaults.
 
@@ -18,17 +22,11 @@ File Links now support block anchors (` ^block-anchor`)! This means that you can
 
 - More information: [[File Links|dendron://dendron.dendron-site/dendron.topic.links#file-links]]
 
-New defaults on Dendron `id` in new note frontmatter:
-- lowercase
-- alphanumeric
-- 23 characters long
-
-- More information: [[Frontmatter id|dendron://dendron.dendron-site/dendron.topic.frontmatter#id]]
-
 ## Highlights
 - enhance(pods): add vault filter for pods-v2 hierarchy export
 - enhance(notes): change dendron id format to be alphanumeric lowercase
 - enhance(workspace): Block Anchor support for non-note files
+- deprecate(publishing): Legacy publishing has now been removed from `dendron-cli`. Dendron users that haven't yet migrated from `dendron buildSite` commands must migrate to using the `dendron publish` commands.
 
 ## Everything Else
 - enhance(workspace): calculate backlinks and anchors in engine for improved editor responsiveness
@@ -39,6 +37,10 @@ New defaults on Dendron `id` in new note frontmatter:
 - fix(publish): properly set siteIndex when it's not explicitly set by config
 
 ## Community
+
+### General
+
+- We added [bookmark bot](https://top.gg/bot/453939662168260612) to the Dendron Discord, meaning that users can now react to a message with `:bookmark:` 🔖 and Bookmarker will save it for them in a direct message.
 
 ### Starboard and TIL Highlights
 <!-- TODO: update links. Delete section is no new items-->

--- a/vault/changelog.release.2022-02-22.md
+++ b/vault/changelog.release.2022-02-22.md
@@ -2,13 +2,13 @@
 id: ixhyxsx79zqjy25s7q9liud
 title: '0.83'
 desc: ''
-updated: 1645493812159
+updated: 1645552134043
 created: 1645488383028
 ---
 
 Dendron 0.83 has sprouted  🌱
 
-**Breaking changes:** This release of Dendron updates the publishing configuration within `dendron.yml`. This update is not backwards compatible, meaning that older versions of `dendron-cli` will not be able to publish a migrated workspace.
+**Breaking changes:** This release of Dendron updates the publishing configuration within `dendron.yml`. Updated workspaces will not work with older version of `dendron-cli`, so make sure to update.
 
 - More information: [[0.83 Changelog|dendron://dendron.dendron-site/changelog.release.2022-02-22#changelog]].
 
@@ -16,7 +16,7 @@ Pod V2 preview continues to grow: you can now export the contents of a hierarchy
 
 - More information: [[Pod v2 exportScope|dendron://dendron.dendron-site/dendron.topic.pod-v2.config#exportscope]]
 
-File Links now support block anchors (` ^block-anchor`)! This means that you can create comments in your code, and link directly to the comment blocks. Optionally, you can link line numbers.
+File Links now support block anchors (` ^block-anchor`)! This means that you can create comments in your code, and link directly to the comment blocks. This is configurable to use the older method of linking to line numbers.
 
 > Block anchors are more reliable because they will always refer to the marked line, but Dendron has to modify the file to insert a block anchor which looks like `^this`. You are free to move the anchor anywhere in the file or to put comment markers like `//` or `#` or anything else before them.
 
@@ -30,7 +30,7 @@ File Links now support block anchors (` ^block-anchor`)! This means that you can
 
 ## Everything Else
 - enhance(workspace): calculate backlinks and anchors in engine for improved editor responsiveness
-- fix(workspace): Journal Note Consistency with Title and Traits
+- fix(workspace): Fixed instances where Journal note `title` values weren't properly formatted as `yyyy-MM-dd` and the `traitID` of `journalNote` wasn't being applied
 - fix(workspace): Dendron will try to parse non-dendron files in `onFirstOpen`
 - fix(workspace): error message to be readable in error toast
 - fix(publish): horizontal line's height in publishing
@@ -125,6 +125,36 @@ This week's entry in the [[Dendron Reading Series|dendron://dendron.dendron-site
 
 A big **thanks** to the following gardeners that brought up issues, contributions, and fixes to this release :man_farmer: :woman_farmer: 
 Visit [[Discord Roles|dendron://dendron.dendron-site/community.discord.roles]] for more information.
+
+- [Im](https://github.com/immartian)
+  - [Issue: Feedback on Graph View](https://github.com/dendronhq/dendron-site/issues/395)
+  
+- [Callum Mcdonald](https://github.com/chmac) `@chmac#2931`
+  - [Issue: Greenhouse Event link to A Day in Dendron is broken](https://github.com/dendronhq/dendron-site/issues/370)
+  
+- [Vincent Dansereau](https://github.com/13013SwagR)
+  - #role.taxonomist
+  - [Issue: css edit link points to documentation that doesn't exists anymore](https://github.com/dendronhq/dendron-site/issues/383)
+
+- [James Henry](https://github.com/henry-js) `@henry-js#6283`
+  - #role.taxonomist
+  - [Troubleshooting `#lookup-shortcut-is-not-working` for Vim extension conflicts](https://github.com/dendronhq/dendron-site/issues/357)
+  
+- [Tycholiz](https://github.com/Tycholiz) `@Tychronos#6624`
+  - [Issue: Select vault not working as intended: not all vaults showing up](https://github.com/dendronhq/dendron/issues/2445)
+  
+- [Ryan Hill](https://github.com/rlh1994) `@rlh1994#9754`
+  - [Issue: Page not publishing with publishByDefault: false and front matter published: true](https://github.com/dendronhq/dendron/issues/2463)
+
+#### Surveyors
+
+A huge thanks to the following Dendronites that provided feedback in the [2022 Dendron User Survey](https://link.dendron.so/74EI). If you would like to help us improve Dendron, please checkout the survey (and earn a shiny [[Surveyor|dendron://dendron.dendron-site/community.discord.roles#surveyor]] Discord badge in the process)!
+
+- `@Idan#8549`
+- `@aleksey#5276`
+- `@d1onysus#1514`
+- `@foureyedsoul#0796`
+- `@cro#4610`
 
 ## Changelog
 ![[dendron://dendron.dendron-site/changelog#0830,1:#0820]]

--- a/vault/changelog.release.2022-02-22.md
+++ b/vault/changelog.release.2022-02-22.md
@@ -1,0 +1,128 @@
+---
+id: ixhyxsx79zqjy25s7q9liud
+title: '0.83'
+desc: ''
+updated: 1645493265012
+created: 1645488383028
+---
+
+Dendron 0.83 has sprouted  🌱
+
+Pod V2 preview continues to grow: you can now export the contents of a hierarchy, filtered by a target vault. This means the multi-vault workspaces can be more targeted in their exports without including notes from undesired vaults.
+
+- More information: [[Pod v2 exportScope|dendron://dendron.dendron-site/dendron.topic.pod-v2.config#exportscope]]
+
+File Links now support block anchors (` ^block-anchor`)! This means that you can create comments in your code, and link directly to the comment blocks. Optionally, you can link line numbers.
+
+> Block anchors are more reliable because they will always refer to the marked line, but Dendron has to modify the file to insert a block anchor which looks like `^this`. You are free to move the anchor anywhere in the file or to put comment markers like `//` or `#` or anything else before them.
+
+- More information: [[File Links|dendron://dendron.dendron-site/dendron.topic.links#file-links]]
+
+New defaults on Dendron `id` in new note frontmatter:
+- lowercase
+- alphanumeric
+- 23 characters long
+
+- More information: [[Frontmatter id|dendron://dendron.dendron-site/dendron.topic.frontmatter#id]]
+
+## Highlights
+- enhance(pods): add vault filter for pods-v2 hierarchy export
+- enhance(notes): change dendron id format to be alphanumeric lowercase
+- enhance(workspace): Block Anchor support for non-note files
+
+## Everything Else
+- enhance(workspace): calculate backlinks and anchors in engine for improved editor responsiveness
+- fix(workspace): Journal Note Consistency with Title and Traits
+- fix(workspace): Dendron will try to parse non-dendron files in `onFirstOpen`
+- fix(workspace): error message to be readable in error toast
+- fix(publish): horizontal line's height in publishing
+- fix(publish): properly set siteIndex when it's not explicitly set by config
+
+## Community
+
+### Starboard and TIL Highlights
+<!-- TODO: update links. Delete section is no new items-->
+> These are highlights from the [[Dendron Discord|dendron://dendron.dendron-site/community.discord.channels]] `#starboard` and `#today-i-learned` channels.
+
+- ⭐ `seadude` shared how to create clickable areas of images that he found useful in [reveal.js presentations](https://marketplace.visualstudio.com/items?itemName=evilz.vscode-reveal): _"Today I learned you can create a clickable area (or more than one) of an image and have it link anywhere."_
+    - Useful for RevealJS presentations, etc.
+    - Done by using the `usemap` parameter of `<img>` and `<map>` HTML tags
+    - Example:
+
+    ```html
+    <img src="https://c.pxhere.com/photos/70/93/egg_hammer_threaten_violence_fear_intimidate_hit_beat-767438.jpg!d" usemap="#map" height="550"/>
+
+    <map name="map">
+        <area shape="circle" coords="330,350,50" alt="egg" href=".\assets\pdfs\timeline2.pdf" target="_blank">
+        <area shape="circle" coords="430,250,50" alt="mallet" href=".\assets\pdfs\timeline3.pdf" target="_blank">
+    </map>
+    ```
+
+- 💡 `seadude` shared information about [VS Code Snippets](https://code.visualstudio.com/docs/editor/userdefinedsnippets):
+    - Related: [Dendron Snippet Maker](https://marketplace.visualstudio.com/items?itemName=dendron.dendron-snippet-maker)
+    - Example 1: You can set a default value for a variable by using a colon (`:`). The `DUE:` property in the below snippet defaults to the current current month, date, hour but can be modified.
+
+    ```json
+    "TODO": {
+    "prefix": "stodo",
+    "body": [
+        "- [ ] ${1:Enter Task}",
+        "- **CAPTURED:**        ${CURRENT_YEAR}-${CURRENT_MONTH}-${CURRENT_DATE}T${CURRENT_HOUR}:${CURRENT_MINUTE}:${CURRENT_SECOND}-08:00",
+        "- **DUE:**             ${CURRENT_YEAR}-${2:${CURRENT_MONTH}}-${3:${CURRENT_DATE}}T${4:${CURRENT_HOUR}}:${5:${CURRENT_MINUTE}}:00-08:00",
+        "- **PRIORITY:**        ${6|HIGH,MEDIUM,LOW|}",
+        "- **STATUS:**          ${7|TODO,WAITING,IN PROGRESS,DONE|}",
+        "- **NOTES:**           ",
+        "    - $0",
+        ],
+        "description": "Capture new TODO"
+    }
+    ```
+
+    - Example 2: You can set dropdown values for a variable using a pipe (`|`).
+
+    ```json
+    "Context Switch": {
+      "prefix": "scontext",
+      "body": [
+        "- **TYPE:**          ${1|COMMS,SUPPORT,RESEARCH,MEETING,DEVELOPMENT,TESTING,VALIDATION,CI/CD,PROJECT MGMT,CONSULTING,DOCUMENTATION,ADMINISTRATION,TRAINING,BREAK|}",
+        "- **PROJECT:**       ${2|PROJ1,PROJ2|}",
+        "- **TOOLS:**         ${3|N/A,PYTHON,AZURE,POWER APPS,POWER AUTOMATE,POWER BI,SHAREPOINT,DENDRON|}",
+        "- **START:**         ${CURRENT_YEAR}-${CURRENT_MONTH}-${CURRENT_DATE}T${CURRENT_HOUR}:{$CURRENT_MINUTE}:${CURRENT_SECOND}-08:00",
+        "- **END:**           ",
+        "- **DURATION:**      ",
+        "- **NOTES:**         ",
+        "    - $0",
+        "---"
+        ],
+        "description": "Capture new context switch"
+    }
+    ```
+
+- 💡 `scriptautomate` shared a link to the [Sourcegraph VS Code extension](https://marketplace.visualstudio.com/items?itemName=sourcegraph.sourcegraph): _"TIL about the Sourcegraph extension for VS Code. I feel like it has interesting potential. Like, imagine searching public Dendron vaults directly from your VS Code?"_
+
+### Dendron Reading Series
+
+This week's entry in the [[Dendron Reading Series|dendron://dendron.dendron-site/community.events.reading-series]].
+
+![[dendron://dendron.dendron-site/community.events.reading-series.2022.02.22]]
+
+### Event Reminders
+
+- **Greenhouse Talks:** Visit the [[Greenhouse Talks|dendron://dendron.dendron-site/community.events.greenhouse]] for notes from previous sessions.
+    - Subject: _Getting Things Done (GTD) and Other Task-Management Workflows (with Dendron!)_
+    - Description: _Interested speakers from the community will take 5 - 10 minutes each to present their workflows for managing actionable information, followed by an open discussion. The event will be recorded and later published online._
+    - Next: [Fri, Feb 25, 4:00 PM PST / 00:00 UTC](https://link.dendron.so/luma)
+    - [Greenhouse Talk Recordings - YouTube Playlist](https://link.dendron.so/greenhouse)
+- **Office Hours:** Visit the [[Office Hours page|dendron://dendron.dendron-site/community.events.office-hours]] for notes from previous sessions.
+    - Next: [Wed, Mar 02, 9:00 AM - 9:30 AM PST](https://link.dendron.so/luma)
+    - [Office Hour Recordings - YouTube Playlist](https://link.dendron.so/6yPa)
+- **New User Tuesdays:** Visit the [[New User Tuesdays page|dendron://dendron.dendron-site/community.events.new-user-tuesdays]] for notes from previous sessions.
+    - Next: [Tue, Mar 08, 8:30 AM - 9:00 AM PST](https://link.dendron.so/luma)
+
+### Thank You's
+
+A big **thanks** to the following gardeners that brought up issues, contributions, and fixes to this release :man_farmer: :woman_farmer: 
+Visit [[Discord Roles|dendron://dendron.dendron-site/community.discord.roles]] for more information.
+
+## Changelog
+![[dendron://dendron.dendron-site/changelog#0830,1:#0820]]

--- a/vault/changelog.release.2022-02-22.md
+++ b/vault/changelog.release.2022-02-22.md
@@ -2,7 +2,7 @@
 id: ixhyxsx79zqjy25s7q9liud
 title: '0.83'
 desc: ''
-updated: 1645552134043
+updated: 1645552850817
 created: 1645488383028
 ---
 
@@ -52,7 +52,7 @@ File Links now support block anchors (` ^block-anchor`)! This means that you can
     - Example:
 
     ```html
-    <img src="https://c.pxhere.com/photos/70/93/egg_hammer_threaten_violence_fear_intimidate_hit_beat-767438.jpg!d" usemap="#map" height="550"/>
+    <img src="https://example.com/image.jpg" usemap="#map" height="550"/>
 
     <map name="map">
         <area shape="circle" coords="330,350,50" alt="egg" href=".\assets\pdfs\timeline2.pdf" target="_blank">

--- a/vault/community.events.reading-series.2022.02.15.md
+++ b/vault/community.events.reading-series.2022.02.15.md
@@ -1,10 +1,10 @@
 ---
 id: OGhGvTM9GlW0jXjXDLiBl
 title: >-
-    20 - Your future self will thank you: Building your personal documentation 
+    20 - Your future self will thank you: Building your personal documentation
 desc: >-
     From the ReadME Project GitHub Blog: Monica explains how to build a second brain of knowledge you'll use over and over.
-updated: 1644861410288
+updated: 1645491620419
 created: 1644856540588
 ---
 

--- a/vault/community.events.reading-series.2022.02.22.md
+++ b/vault/community.events.reading-series.2022.02.22.md
@@ -1,0 +1,32 @@
+---
+id: yok991f5wlfiy96jg5tnidc
+title: >-
+    21 - Hundreds of Ways to Get S#!+ Done—and We Still Don't
+desc: "A critical take on the profusion of productivity apps and what works, what doesn't."
+updated: 1645493111466
+created: 1645491595185
+---
+
+- [Hundreds of Ways to Get S#!+ Done—and We Still Don't](https://www.wired.com/story/to-do-apps-failed-productivity-tools/)
+
+> Credit to `Jack of some quantity of trades#3247`, a [[Dendrologist|community.discord.roles#dendrologist]] from the Dendron community, for contributing the link and summary for this week's Dendron Reading Series!
+
+Even with all the best tools, are you still struggling to get things done?
+
+Data suggests that people mainly uses to-do lists and associated productivity software to _manage their mood_ rather than to _organize their activities_. Typically, the contents of to-do lists is poorly correlated with things accomplished, which seem to usually be what people remember on the spur of the moment or felt like doing anyway.
+
+Of all technology, productivity software is rather uniquely suited to evoke experiences of _guilt_ and _virtue_ (this has something to do with the Protestant work ethic). Adding items to to-do lists allows us to maintain the conceit that we will take care of them at some point, providing a semblance of cognitive and emotional relief. Though, since people usually don't actually do the things on their lists, they become "lists of shame" that continue accumulating until they are abandoned in "productivity bankruptcy."
+
+Ultimately, the drive to adopt productivity tools and methods may reflect the fear of death ("We like lists because we do not want to die"); having a sense of our mortality and finite time, and wanting to accomplish our infinite ambitions and desires.
+
+All of this may be rather bleak, but there are a couple prescriptions that emerge from this perspective:
+
+1. More effective use of lists of tasks may be made by assigning them to specific blocks of time in a schedule. This kind of planning forces us to come to terms with what it is actually possible for us to accomplish.
+2. We can avoid generating "lists of shame" by making sure that the rates at which we are adding to our to-do lists are comparable with the rates at which we are completing tasks. This may require reconciling oneself with one's mortality and accepting existential limits.
+
+## Related
+
+- [Four Thousand Weeks: Time Management for Mortals](https://www.harvard.com/book/four_thousand_weeks/), of Oliver Burkeman: This book discusses prescription #2 in some depth 
+- [Life as Nonproductive Act](https://drmaciver.substack.com/p/life-as-nonproductive-act), from David McLaver's _Overthinking Everything_ substack: Contains some musings about the Protestant work ethic in contemporary circumstances.
+- [Complice: Beyong Getting Things Done](https://malcolmocean.com/2020/12/complice-is-more-than-getting-things-done/)
+  - The Complice paradigm is designed with some of these things in mind, eschewing exhaustive collection in favor of focusing on what is most important on a day-to-day basis. Productivity software that implements Complice is typically designed to prevent the accumulation of lists of shame by preventing the user from unreflectively carrying tasks over from day to day, among other design features.

--- a/vault/dendron.topic.publish.md
+++ b/vault/dendron.topic.publish.md
@@ -15,7 +15,7 @@ Dendron lets you publish all your notes as static HTML which you can host anywhe
 
 This site that you are looking at is published using Dendron. 
 
-Checkout our [[quickstart guide|dendron://dendron.dendron-site/dendron.topic.publish.cook.github]] for publishing to GitHub Pages to get started
+Checkout our [[GitHub Pages with GitHub Actions|dendron://dendron.dendron-site/dendron.topic.publish.cook.github-action]] for publishing to GitHub Pages to get started.
 
 ## Details
 

--- a/vault/dendron.topic.publish.migration.md
+++ b/vault/dendron.topic.publish.migration.md
@@ -8,9 +8,9 @@ created: 1632351743935
 
 ## Upgrade Instructions
 
-If you are coming from Dendron's legacy publishing (based on 11ty), you can look at the following guides for publishing. 
+If you are coming from Dendron's legacy publishing (based on 11ty), you can look at the following guides for publishing.
 
-If you were publishing using github pages without using github actions, follow the [[GitHub Pages|dendron://dendron.dendron-site/dendron.topic.publish.cook.github]] guide
+If you were publishing using github pages without using github actions, follow the [[GitHub Pages|dendron://dendron.dendron-site/dendron.topic.publish.cook.github]] guide.
 
 If you were publishing using github pages with github actions, follow the [[GitHub Pages with GitHub Actions|dendron://dendron.dendron-site/dendron.topic.publish.cook.github-action]] guide.
 

--- a/vault/templates.release.weekly-public-announcement.md
+++ b/vault/templates.release.weekly-public-announcement.md
@@ -2,7 +2,7 @@
 id: 1ec8d588-7c8a-47a2-b79e-1dd02d10b600
 title: Weekly Public Announcement
 desc: ''
-updated: 1641838148712
+updated: 1645491261234
 created: 1622484182130
 ---
 
@@ -11,38 +11,43 @@ title: 0.7
 
 Dendron 0.7 has sprouted  🌱
 
-### Highlights
+## Highlights
 
-### Everything Else
+## Everything Else
 
-### Community
+## Community
 
-#### General Updates
+### General Updates
 <!-- TODO: Delete this section if not appliacble -->
 
-#### Starboard and TIL Highlights
+### Starboard and TIL Highlights
 <!-- TODO: update links. Delete section is no new items-->
 > These are highlights from the [[Dendron Discord|dendron://dendron.dendron-site/community.discord.channels]] `#starboard` and `#today-i-learned` channels.
 
 - ⭐ `username` shared a link to [link](example.com): _"Quote used when sharing link"_
 - 💡 `username` shared a link to [link](example.com): _"Quote used when sharing link"_
 
-#### Dendron Reading Series
+### Dendron Reading Series
 
 This week's entry in the [[Dendron Reading Series|dendron://dendron.dendron-site/community.events.reading-series]].
 
-#### Office Hours and New User Tuesdays
+### Event Reminders
 
+- **Greenhouse Talks:** Visit the [[Greenhouse Talks|dendron://dendron.dendron-site/community.events.greenhouse]] for notes from previous sessions.
+    - Subject: _Getting Things Done (GTD) and Other Task-Management Workflows (with Dendron!)_
+    - Description: _Interested speakers from the community will take 5 - 10 minutes each to present their workflows for managing actionable information, followed by an open discussion. The event will be recorded and later published online._
+    - Next: [Fri, Feb 25, 4:00 PM PST / 00:00 UTC](https://link.dendron.so/luma)
+    - [Greenhouse Talk Recordings - YouTube Playlist](https://link.dendron.so/greenhouse)
 - **Office Hours:** Visit the [[Office Hours page|dendron://dendron.dendron-site/community.events.office-hours]] for notes from previous sessions.
-    - [YouTube Playlist](https://link.dendron.so/6yPa)
-    - Next: [Wed, Jan 19, 9:00 AM - 9:30 AM PST](https://link.dendron.so/luma)
+    - Next: [Wed, Mar 02, 9:00 AM - 9:30 AM PST](https://link.dendron.so/luma)
+    - [Office Hour Recordings - YouTube Playlist](https://link.dendron.so/6yPa)
 - **New User Tuesdays:** Visit the [[New User Tuesdays page|dendron://dendron.dendron-site/community.events.new-user-tuesdays]] for notes from previous sessions.
-    - Next: [Tue, Jan 25, 8:30 AM - 9:00 AM PST](https://link.dendron.so/luma)
+    - Next: [Tue, Mar 08, 8:30 AM - 9:00 AM PST](https://link.dendron.so/luma)
 
-#### Thank You's
+### Thank You's
 
 A big **thanks** to the following gardeners that brought up issues, contributions, and fixes to this release :man_farmer: :woman_farmer: 
 Visit [[Discord Roles|dendron://dendron.dendron-site/community.discord.roles]] for more information.
 
-### Changelog
+## Changelog
 ![[changelog#0760,1:#0750]]


### PR DESCRIPTION
## Summary

- Release notes and changelog for 0.83
- Dendron Reading Series for 0.83
- Updates to base release notes template to include Greenhouse Talks in event reminders

## Remaining

- [x] Contributors information