### PR TITLE
chore: fix typo in publish config page

### DIFF
--- a/vault/dendron.topic.publish.config.md
+++ b/vault/dendron.topic.publish.config.md
@@ -122,7 +122,7 @@ These are properties related to SEO of the published site.
   - [[twitter|dendron.topic.publish.config.seo.twitter]]
   - [[image|dendron.topic.publish.config.seo.image]]
 
-## GitHib properties
+## GitHub properties
 These are properties related to GitHub.
 
 - [[github|dendron.topic.publish.config.github]]


### PR DESCRIPTION
"GitHub" was misspelled as "GitHib" in the page about publish configuration.