### PR TITLE
Add CROP 2022-03-23

### DIFF
--- a/vault/community.events.crop.2022.03.23.md
+++ b/vault/community.events.crop.2022.03.23.md
@@ -1,0 +1,16 @@
+---
+id: kdy47icfpvtx0q57ddiwt4n
+title: 'CROP - 2022-03-23'
+desc: ''
+updated: 1648489588371
+created: 1648489588371
+---
+
+The winner of this CROP is [Lookup stops working properly after pressing tab](https://github.com/dendronhq/dendron/issues/2550) submitted by [@chmac](https://github.com/chmac)🎉.
+
+Other entries participating in this CROP are
+
+- [Lookup: Enable automatic space to '-' conversion upon note creation](https://github.com/dendronhq/dendron/issues/2514) by [@nickolay-kondratyev](https://github.com/nickolay-kondratyev)
+- [Lookup: Missing space between note title and vault name](https://github.com/dendronhq/dendron/issues/2467) by [@cconrad](https://github.com/cconrad)
+
+See the [Discord thread](https://discord.com/channels/717965437182410783/739186036495876126/956202441387425862) for more information and vote counts.

--- a/vault/community.events.crop.2022.04.06.md
+++ b/vault/community.events.crop.2022.04.06.md
@@ -1,0 +1,16 @@
+---
+id: zdv5l16bt9cnt62ssy8vghy
+title: 'CROP - 2022-04-06'
+desc: ''
+updated: 1650498446746
+created: 1650498139895
+---
+
+The winner of this CROP is [Optional publishing under original filenames?](https://github.com/dendronhq/dendron/issues/331) submitted by [@tmladek](https://github.com/tmladek)🎉.
+
+Other entries participating in this CROP are
+
+- [Ability to remove children and backlinks](https://github.com/dendronhq/dendron/issues/2000) by [@taeboki](https://github.com/taeboki)
+- [Allow override of lookup sorting results](https://github.com/dendronhq/dendron/issues/2504) by [@nickolay-kondratyev](https://github.com/nickolay-kondratyev)
+
+See the [Discord thread](https://discord.com/channels/717965437182410783/739186036495876126/961452441235238953) for more information and vote counts.


### PR DESCRIPTION
## What does this PR do?

- adds the CROP event from 2022-03-23

### Merge requirements satisfied

> For more information, visit the [Contributing Guide for Documentation](https://wiki.dendron.so/notes/b58801fc-43a9-4d42-a58b-eabc3e8538cb/)

- [x] Check rendered output to ensure formatting is correct for renderings of wikilinks, note refs, tables, and images. `Dendron: Show Preview` can be used in your workspace to confirm the page renders as expected. Sometimes, `Dendron: Reload Index` needs to be ran if certain wikilinks aren't working as expected. (ignore this if contribution is made via the `Edit this page on GitHub` button from the published site)
- [-] If this PR includes any refactoring (renaming notes, renaming headers, etc.), make sure that these changes were done via [Dendron Refactoring Commands](https://wiki.dendron.so/notes/srajljj10V2dl19nCSFiC/). This will ensure that any other impacted areas of the documentation, that link to or embed modified notes (via note references), are automatically updated.

Verify GitHub Actions tests are passing, which can be seen in the `Checks` tab of the PR:

- [x] `URL validator` GitHub Action passes
- [x] `Dendron site build` GitHub Action passes

> **NOTE:** If you are a new contributor, a maintainer will need to provide approval for GitHub Actions to run on your PRs.
