### PR TITLE
Early Seed 0.86

### DIFF
--- a/vault/changelog.early-seed.md
+++ b/vault/changelog.early-seed.md
@@ -10,11 +10,21 @@ nav_exclude: true
 
 > This page documents the features, enhancements, and fixes in the latest early seed release. The early seed is a preview of the weekly release, so you'll see the next minor version when installing (ex. `0.78.0` instead of `0.77.1`). When dendron ships the general release, the currently installed extension will automatically be updated (but will still have same version).
 
-## 0.88.0
+## 0.89.0
+
+Dendron 0.89 has sprouted 🌱
+
+Interested in contributing to the development of Dendron? We've added a [CONTRIBUTING.md](https://github.com/dendronhq/dendron/blob/master/CONTRIBUTING.md) file so that you can find out how to get started shaping the future of Dendron!
+
+### Features
+- feat(workspace): detect and fill missing default configs on extension upgrade ([[docs|dendron://dendron.dendron-site/dendron.topic.doctor#addmissingdefaultconfigs]]) @hikchoi
 
 ### Enhancements
-- enhance(workspace): improve the error message for bad or missing code-workspace file (#2600) @kaan
-- enhance(workspace): initialize workspace can create self contained vaults ([[docs|dendron://dendron.dendron-site/dendron.topic.vaults.self-contained##configuration]]) (#2569) @kaan
+- enhance: create CONTRIBUTING.md file (#2567) @kevin
 
 ### Fix
-- fix(workspace): fix dropped keystrokes issue in lookup (#2626) @jonathan
+- fix(workspace): typo in dendron.yml (#2636) @kevin
+- fix(markdown): issue with angle brackets syntax in mermaid  (#2637) @kaan
+- fix(workspace): updated timestamp not updating properly on save (#2651) @tuling
+- fix(workspace): copyNoteLink not getting updated title if note isn't saved (#2631) @tuling
+- fix(views): dendron-next-server to pass port-forwarded url (#2671) @joshi


### PR DESCRIPTION
## What does this PR do?
<!-- Describe pull request here. -->

- Early Seed Changelog updates for v0.86.

> **NOTE:** `Fixes` will close the ticket after merging. `Relates to:` will leave the ticket open after merging.

### Merge requirements satisfied

> For more information, visit the [Contributing Guide for Documentation](https://wiki.dendron.so/notes/b58801fc-43a9-4d42-a58b-eabc3e8538cb/)

- [ ] Check rendered output to ensure formatting is correct for renderings of wikilinks, note refs, tables, and images. `Dendron: Show Preview` can be used in your workspace to confirm the page renders as expected. Sometimes, `Dendron: Reload Index` needs to be ran if certain wikilinks aren't working as expected. (ignore this if contribution is made via the `Edit this page on GitHub` button from the published site)
- [ ] If this PR includes any refactoring (renaming notes, renaming headers, etc.), make sure that these changes were done via [Dendron Refactoring Commands](https://wiki.dendron.so/notes/srajljj10V2dl19nCSFiC/). This will ensure that any other impacted areas of the documentation, that link to or embed modified notes (via note references), are automatically updated.

Verify GitHub Actions tests are passing, which can be seen in the `Checks` tab of the PR:

- [ ] `URL validator` GitHub Action passes
- [ ] `Dendron site build` GitHub Action passes

> **NOTE:** If you are a new contributor, a maintainer will need to provide approval for GitHub Actions to run on your PRs.
