### PR TITLE
added telemetry for Show Note Graph Command

### DIFF
--- a/vault/dendron.ref.telemetry.md
+++ b/vault/dendron.ref.telemetry.md
@@ -2,7 +2,7 @@
 id: 84df871b-9442-42fd-b4c3-0024e35b5f3c
 title: Telemetry
 desc: ""
-updated: 1649328298064
+updated: 1649412483697
 created: 1619460500071
 nav_order: 6.1
 ---
@@ -175,7 +175,7 @@ To understand how the users take advantage of our graph view feature, we also co
 
 |               Field | Attributes | Description                                                               |
 | ------------------: | :--------: | ------------------------------------------------------------------------- |
-| `timespan` | _number_  | The duration for which Note Graph was used. |
+| `timeOpen` | _number_  | The duration for which Note Graph was used. |
 | `message` | _string_  | Was the graph view used for navigation? |
 
 ### CLI commands

--- a/vault/dendron.ref.telemetry.md
+++ b/vault/dendron.ref.telemetry.md
@@ -2,7 +2,7 @@
 id: 84df871b-9442-42fd-b4c3-0024e35b5f3c
 title: Telemetry
 desc: ""
-updated: 1647962982565
+updated: 1649328298064
 created: 1619460500071
 nav_order: 6.1
 ---
@@ -168,6 +168,15 @@ We use this as a simple way to simulate a copy button within a rendered markdown
 |               Field | Attributes | Description                                                               |
 | ------------------: | :--------: | ------------------------------------------------------------------------- |
 | `source` | _string_  | Name of the webview that this command was invoked. |
+
+#### Show Note Graph
+
+To understand how the users take advantage of our graph view feature, we also collect the following data if `Show Note Graph` command is used.
+
+|               Field | Attributes | Description                                                               |
+| ------------------: | :--------: | ------------------------------------------------------------------------- |
+| `timespan` | _number_  | The duration for which Note Graph was used. |
+| `message` | _string_  | Was the graph view used for navigation? |
 
 ### CLI commands
 


### PR DESCRIPTION
## What does this PR do?
<!-- Describe pull request here. -->
This PR updates the telemetry for Show Note Graph Command

## What issues does this PR fix or reference?
<!-- Delete section or leave empty if no related GitHub Issue exists -->

- Fixes:
OR
- Relates to:

> **NOTE:** `Fixes` will close the ticket after merging. `Relates to:` will leave the ticket open after merging.

### Merge requirements satisfied

> For more information, visit the [Contributing Guide for Documentation](https://wiki.dendron.so/notes/b58801fc-43a9-4d42-a58b-eabc3e8538cb/)

- [x] Check rendered output to ensure formatting is correct for renderings of wikilinks, note refs, tables, and images. `Dendron: Show Preview` can be used in your workspace to confirm the page renders as expected. Sometimes, `Dendron: Reload Index` needs to be ran if certain wikilinks aren't working as expected. (ignore this if contribution is made via the `Edit this page on GitHub` button from the published site)
- [~] If this PR includes any refactoring (renaming notes, renaming headers, etc.), make sure that these changes were done via [Dendron Refactoring Commands](https://wiki.dendron.so/notes/srajljj10V2dl19nCSFiC/). This will ensure that any other impacted areas of the documentation, that link to or embed modified notes (via note references), are automatically updated.

Verify GitHub Actions tests are passing, which can be seen in the `Checks` tab of the PR:

- [ ] `URL validator` GitHub Action passes
- [x] `Dendron site build` GitHub Action passes

> **NOTE:** If you are a new contributor, a maintainer will need to provide approval for GitHub Actions to run on your PRs.
