### PR TITLE
Fix note ref on upgrading CLI in publish notes

### DIFF
--- a/vault/dendron.topic.publish.migration.md
+++ b/vault/dendron.topic.publish.migration.md
@@ -2,7 +2,7 @@
 id: rYbs1qLh9VJBXCJlSzMt4
 title: Migration
 desc: ''
-updated: 1646332526178
+updated: 1650378725026
 created: 1632351743935
 ---
 
@@ -16,7 +16,7 @@ Please note that if you have an automated pipeline set up for publishing that us
 
 If there is a compatibility mismatch, running the CLI will display a message that the version does not meet the minimum compatible version. If you see this message, please upgrade `dendron-cli` to the latest version.
 
-![[dendron://dendron.dendron-site/dendron.topic.cli.upgrade#steps,1:#*]]
+![[dendron://dendron.dendron-site/dendron.topic.cli.upgrade#steps,1]]
 
 ## Upgrade dendron.yml configurations
 


### PR DESCRIPTION
## What does this PR do?

Broken note ref in Migration guide for publishing, which [can be seen here](https://wiki.dendron.so/notes/rYbs1qLh9VJBXCJlSzMt4/#upgrade-dendron-cli). I noticed this when working on:

- https://github.com/dendronhq/template.publish.netlify/pull/4

## What issues does this PR fix or reference?
<!-- Delete section or leave empty if no related GitHub Issue exists -->

- Fixes:
OR
- Relates to:

> **NOTE:** `Fixes` will close the ticket after merging. `Relates to:` will leave the ticket open after merging.

### Merge requirements satisfied

> For more information, visit the [Contributing Guide for Documentation](https://wiki.dendron.so/notes/b58801fc-43a9-4d42-a58b-eabc3e8538cb/)

- [x] Check rendered output to ensure formatting is correct for renderings of wikilinks, note refs, tables, and images. `Dendron: Show Preview` can be used in your workspace to confirm the page renders as expected. Sometimes, `Dendron: Reload Index` needs to be ran if certain wikilinks aren't working as expected. (ignore this if contribution is made via the `Edit this page on GitHub` button from the published site)
- [x] If this PR includes any refactoring (renaming notes, renaming headers, etc.), make sure that these changes were done via [Dendron Refactoring Commands](https://wiki.dendron.so/notes/srajljj10V2dl19nCSFiC/). This will ensure that any other impacted areas of the documentation, that link to or embed modified notes (via note references), are automatically updated.

Verify GitHub Actions tests are passing, which can be seen in the `Checks` tab of the PR:

- [ ] `URL validator` GitHub Action passes
- [ ] `Dendron site build` GitHub Action passes

> **NOTE:** If you are a new contributor, a maintainer will need to provide approval for GitHub Actions to run on your PRs.
