### PR TITLE
Update docs for new doctor action

### DIFF
--- a/vault/dendron.topic.doctor.md
+++ b/vault/dendron.topic.doctor.md
@@ -2,7 +2,7 @@
 id: ZeC74FYVECsf9bpyngVMU
 title: Doctor
 desc: ""
-updated: 1650549222612
+updated: 1651082523945
 created: 1640418184682
 ---
 
@@ -78,6 +78,14 @@ This simply lists all broken links in the scope.
 
 - Command: `Dendron: Doctor`
 - Option: `addMissingDefaultConfigs`
+
+### removeDeprecatedConfigs
+
+- Detects if there are any deprecated configurations that are still in `dendron.yml`.
+- When a deprecated configuration key exists, a backup of `dendron.yml` is created and the deprecated keys are removed.
+
+- Command: `Dendron: Doctor`
+- Option: `removeDeprecatedConfigs`
 
 ### findIncompatibleExtensions
 


### PR DESCRIPTION
## What does this PR do?
- Adds documentation for new doctor action `removeDeprecatedConfigs`

## What issues does this PR fix or reference?

- Relates to: dendronhq/dendron#2841

### Merge requirements satisfied

> For more information, visit the [Contributing Guide for Documentation](https://wiki.dendron.so/notes/b58801fc-43a9-4d42-a58b-eabc3e8538cb/)

- [ ] Check rendered output to ensure formatting is correct for renderings of wikilinks, note refs, tables, and images. `Dendron: Show Preview` can be used in your workspace to confirm the page renders as expected. Sometimes, `Dendron: Reload Index` needs to be ran if certain wikilinks aren't working as expected. (ignore this if contribution is made via the `Edit this page on GitHub` button from the published site)
- [ ] If this PR includes any refactoring (renaming notes, renaming headers, etc.), make sure that these changes were done via [Dendron Refactoring Commands](https://wiki.dendron.so/notes/srajljj10V2dl19nCSFiC/). This will ensure that any other impacted areas of the documentation, that link to or embed modified notes (via note references), are automatically updated.

Verify GitHub Actions tests are passing, which can be seen in the `Checks` tab of the PR:

- [ ] `URL validator` GitHub Action passes
- [ ] `Dendron site build` GitHub Action passes

> **NOTE:** If you are a new contributor, a maintainer will need to provide approval for GitHub Actions to run on your PRs.
