### PR TITLE
Update docs for tree item label type config

### DIFF
--- a/vault/dendron.ref.config.workspace.md
+++ b/vault/dendron.ref.config.workspace.md
@@ -2,7 +2,7 @@
 id: 3i4ABJutl7NGeXRHTnUEC
 title: Workspace
 desc: ''
-updated: 1638518870049
+updated: 1651245228402
 created: 1634646633536
 ---
 
@@ -134,6 +134,22 @@ See [[Graph view|dendron.topic.graph-view]]
 Determines the zoom speed in the graph view.
 
 - default: 1
+
+## views
+
+Namespace for view related configurations.
+
+### treeView
+
+Namespace for tree view related configurations.
+
+#### treeItemLabelType
+
+Sets how the tree items are labeled in the tree view.
+This is also tied to how the tree items are sorted.
+
+- default: "title"
+- options: ["title", "filename"]
 
 ## disableTelemetry
 


### PR DESCRIPTION
## What does this PR do?

This PR adds documents for the new `workspace.views.treeViews` namespace and the config key `treeItemLabelType`

## What issues does this PR fix or reference?
- Relates to: dendronhq/dendron#2858

### Merge requirements satisfied

> For more information, visit the [Contributing Guide for Documentation](https://wiki.dendron.so/notes/b58801fc-43a9-4d42-a58b-eabc3e8538cb/)

- [ ] Check rendered output to ensure formatting is correct for renderings of wikilinks, note refs, tables, and images. `Dendron: Show Preview` can be used in your workspace to confirm the page renders as expected. Sometimes, `Dendron: Reload Index` needs to be ran if certain wikilinks aren't working as expected. (ignore this if contribution is made via the `Edit this page on GitHub` button from the published site)
- [ ] If this PR includes any refactoring (renaming notes, renaming headers, etc.), make sure that these changes were done via [Dendron Refactoring Commands](https://wiki.dendron.so/notes/srajljj10V2dl19nCSFiC/). This will ensure that any other impacted areas of the documentation, that link to or embed modified notes (via note references), are automatically updated.

Verify GitHub Actions tests are passing, which can be seen in the `Checks` tab of the PR:

- [ ] `URL validator` GitHub Action passes
- [ ] `Dendron site build` GitHub Action passes

> **NOTE:** If you are a new contributor, a maintainer will need to provide approval for GitHub Actions to run on your PRs.
