### PR TITLE
Doc changes for #2940

### DIFF
--- a/vault/dendron.ref.telemetry.md
+++ b/vault/dendron.ref.telemetry.md
@@ -2,7 +2,7 @@
 id: 84df871b-9442-42fd-b4c3-0024e35b5f3c
 title: Telemetry
 desc: ""
-updated: 1649412483697
+updated: 1653014473746
 created: 1619460500071
 nav_order: 6.1
 ---
@@ -53,6 +53,10 @@ When a configuration or client version does not meet the minimum compatibility r
 |          `configVersion` |      _string_      | Config version when the mismatch happened                |
 | `minCompatClientVersion` |      _string_      | Minimum compatible client version when mismatch happened |
 | `minCompatConfigVersion` |      _string_      | Minimum compatible config version when mismatch happened |
+
+#### Duplicate configuration key
+
+During activation, if there is a duplicate key mapping in `dendron.yml`, we prompt users that they should remove the duplicate mappings. When doing so, we track that we have prompted, and also track if the user has accepted or rejected the prompt. This helps us understand how users troubleshoot configuration errors and let us improve the way we present instructions.
 
 #### Missing configuration
 


### PR DESCRIPTION
## What does this PR do?
- Add documentation related duplicate config entry detection

## What issues does this PR fix or reference?

- Relates to: dendronhq/dendron#2940

### Merge requirements satisfied

> For more information, visit the [Contributing Guide for Documentation](https://wiki.dendron.so/notes/b58801fc-43a9-4d42-a58b-eabc3e8538cb/)

- [x] Check rendered output to ensure formatting is correct for renderings of wikilinks, note refs, tables, and images. `Dendron: Show Preview` can be used in your workspace to confirm the page renders as expected. Sometimes, `Dendron: Reload Index` needs to be ran if certain wikilinks aren't working as expected. (ignore this if contribution is made via the `Edit this page on GitHub` button from the published site)
- [x] If this PR includes any refactoring (renaming notes, renaming headers, etc.), make sure that these changes were done via [Dendron Refactoring Commands](https://wiki.dendron.so/notes/srajljj10V2dl19nCSFiC/). This will ensure that any other impacted areas of the documentation, that link to or embed modified notes (via note references), are automatically updated.

Verify GitHub Actions tests are passing, which can be seen in the `Checks` tab of the PR:

- [ ] `URL validator` GitHub Action passes
- [x] `Dendron site build` GitHub Action passes

> **NOTE:** If you are a new contributor, a maintainer will need to provide approval for GitHub Actions to run on your PRs.
