### PR TITLE
 feat(views): Preview setting for light, dark, or custom themes

### DIFF
--- a/vault/dendron.topic.theme.md
+++ b/vault/dendron.topic.theme.md
@@ -2,10 +2,9 @@
 id: 1zjrdj4nqo6c5glrnd1ssww
 title: Theme
 desc: ""
-updated: 1652220287438
+updated: 1653545547663
 created: 1652219473936
 ---
 
-You can customize the style used by Dendron! The [[Dendron preview|dendron.topic.theme.preview]]
-will update itself based on whether you are using a light or dark theme in VSCode,
-and [[publishing|dendron.topic.theme.publish]] supports custom themes!
+You can customize the style used by Dendron! Both [[Dendron preview|dendron.topic.theme.preview]]
+and [[publishing|dendron.topic.theme.publish]] let you pick between light and dark themes, or use create your own custom theme! Click on the links above to get started.

--- a/vault/dendron.topic.theme.preview.md
+++ b/vault/dendron.topic.theme.preview.md
@@ -2,14 +2,17 @@
 id: lb9wd7z62ch7b4slscp05i4
 title: Preview
 desc: ""
-updated: 1653545466561
+updated: 1653621115339
 created: 1652220053823
 ---
 
 Dendron's [[Preview|dendron.ref.commands#show-preview]] will automatically
-change it's appearance based on the current VSCode theme: If you are using a
-dark theme in VSCode, the preview will also use a dark theme, and same for light
-themes. You can also override the theme selection, or apply a custom theme!
+change it's appearance based on the current VSCode theme. You can also override
+the theme selection, or apply a custom theme!
+
+<a href="https://www.loom.com/share/053db1930a814d6b93a7818c15b18967">
+<img style="" src="https://cdn.loom.com/sessions/thumbnails/053db1930a814d6b93a7818c15b18967-with-play.gif"> 
+</a>
 
 ## Getting started
 

--- a/vault/dendron.topic.theme.preview.md
+++ b/vault/dendron.topic.theme.preview.md
@@ -2,13 +2,15 @@
 id: lb9wd7z62ch7b4slscp05i4
 title: Preview
 desc: ""
-updated: 1652220176413
+updated: 1653545466561
 created: 1652220053823
 ---
 
 Dendron's [[Preview|dendron.ref.commands#show-preview]] will automatically
-change it's appearance based on the current VSCode theme. If you are using a
+change it's appearance based on the current VSCode theme: If you are using a
 dark theme in VSCode, the preview will also use a dark theme, and same for light
-themes.
+themes. You can also override the theme selection, or apply a custom theme!
 
-We don't support customizing the preview theme yet, but we'll be adding it soon!
+## Getting started
+
+![[dendron.topic.theme.preview.quickstart]]

--- a/vault/dendron.topic.theme.preview.quickstart.md
+++ b/vault/dendron.topic.theme.preview.quickstart.md
@@ -2,7 +2,7 @@
 id: 0fbg5vbv5jzb0623pbi4v3t
 title: Quickstart
 desc: "Getting started customizing the theme for the preview"
-updated: 1653545404371
+updated: 1653621191422
 created: 1653544545225
 ---
 
@@ -61,7 +61,8 @@ You can apply a custom theme by writing a custom CSS file.
    }
    ```
 
-### Going back to the default theme (automatically apply theme matching VSCode)
+### Going back to the default theme (use your current VSCode theme colors)
 
 1. Open the `dendron.yml` file, at the root of your Dendron workspace.
 1. Remove the `preview.theme` configuration.
+1. Close and reopen the note preview.

--- a/vault/dendron.topic.theme.preview.quickstart.md
+++ b/vault/dendron.topic.theme.preview.quickstart.md
@@ -1,0 +1,67 @@
+---
+id: 0fbg5vbv5jzb0623pbi4v3t
+title: Quickstart
+desc: "Getting started customizing the theme for the preview"
+updated: 1653545404371
+created: 1653544545225
+---
+
+## Summary
+
+{{fm.desc}}
+
+## Prerequisites
+
+- Make sure you are using the latest Dendron and VSCode version.
+
+## Steps
+
+### Picking the light or dark theme
+
+1. Open the `dendron.yml` file, at the root of your Dendron workspace.
+1. Edit the `preview.theme` configuration, so the config file will look like the following:
+
+   ```yaml
+   preview:
+     theme: light # or dark
+     ...
+   ```
+
+1. Close and reopen the note preview. It should now use your preferred theme!
+
+### Applying a custom theme
+
+![](https://org-dendron-public-assets.s3.amazonaws.com/images/preview-custom-theme-example.png)
+
+You can apply a custom theme by writing a custom CSS file.
+
+1. Follow the instructions in the [[previous section|dendron://dendron.dendron-site/dendron.topic.theme.preview.quickstart#picking-the-light-or-dark-theme]], but set the theme to `custom` instead.
+1. Create a file named `custom.css` at the root of your workspace, next to the `dendron.yml` file. Inside this file, add the following contents. Modify the colors used however you'd like.
+
+   ```css
+   body {
+     /* The background color of the preview. */
+     background-color: #002b5c;
+   }
+
+   body,
+   h1,
+   h2,
+   h3,
+   h4 {
+     /* Text color for the text, not including links. */
+     color: #ffffff;
+   }
+
+   a,
+   a:hover,
+   a:active {
+     /** Color for links, except ones that have been already visited. */
+     color: #b2f7ef;
+   }
+   ```
+
+### Going back to the default theme (automatically apply theme matching VSCode)
+
+1. Open the `dendron.yml` file, at the root of your Dendron workspace.
+1. Remove the `preview.theme` configuration.


### PR DESCRIPTION
## What does this PR do?
<!-- Describe pull request here. -->

## What issues does this PR fix or reference?
<!-- Delete section or leave empty if no related GitHub Issue exists -->

- Fixes:
OR
- Relates to: https://github.com/dendronhq/dendron/pull/2984

> **NOTE:** `Fixes` will close the ticket after merging. `Relates to:` will leave the ticket open after merging.

### Merge requirements satisfied

> For more information, visit the [Contributing Guide for Documentation](https://wiki.dendron.so/notes/b58801fc-43a9-4d42-a58b-eabc3e8538cb/)

- [ ] Check rendered output to ensure formatting is correct for renderings of wikilinks, note refs, tables, and images. `Dendron: Show Preview` can be used in your workspace to confirm the page renders as expected. Sometimes, `Dendron: Reload Index` needs to be ran if certain wikilinks aren't working as expected. (ignore this if contribution is made via the `Edit this page on GitHub` button from the published site)
- [ ] If this PR includes any refactoring (renaming notes, renaming headers, etc.), make sure that these changes were done via [Dendron Refactoring Commands](https://wiki.dendron.so/notes/srajljj10V2dl19nCSFiC/). This will ensure that any other impacted areas of the documentation, that link to or embed modified notes (via note references), are automatically updated.

Verify GitHub Actions tests are passing, which can be seen in the `Checks` tab of the PR:

- [ ] `URL validator` GitHub Action passes
- [ ] `Dendron site build` GitHub Action passes

> **NOTE:** If you are a new contributor, a maintainer will need to provide approval for GitHub Actions to run on your PRs.
