### PR TITLE
backlinks hover with getting started section

### DIFF
--- a/vault/dendron.topic.sidebar.backlinks.md
+++ b/vault/dendron.topic.sidebar.backlinks.md
@@ -2,7 +2,7 @@
 id: yxkn87ohgomk0tgs12dppur
 title: Backlinks
 desc: ''
-updated: 1653410530655
+updated: 1653630796554
 created: 1653410188509
 ---
 
@@ -11,59 +11,51 @@ This view lets you see all [[backlinks|dendron.topic.links#backlinks]] to the cu
 
 When you create a link anywhere in Dendron, it becomes a backlink to the destination note and will appear in the backlinks view of the destination note.
 
-![](https://cdn.loom.com/images/originals/25fce495c52a475b9a952e1901b93e4c.jpg?Expires=1626335459&Policy=eyJTdGF0ZW1lbnQiOlt7IlJlc291cmNlIjoiaHR0cHM6Ly9jZG4ubG9vbS5jb20vaW1hZ2VzL29yaWdpbmFscy8yNWZjZTQ5NWM1MmE0NzViOWE5NTJlMTkwMWI5M2U0Yy5qcGciLCJDb25kaXRpb24iOnsiRGF0ZUxlc3NUaGFuIjp7IkFXUzpFcG9jaFRpbWUiOjE2MjYzMzU0NTl9fX1dfQ__&Signature=HvqcgNlMGeafss5bfNHzXg1yj6alFAtAuTIOvdunRRUHPUH05AGHr6Cv0uv0rrHVuIRzOXHflqLjKVmrYaF5Xms5NBURrQ8qu0TC6s541TLHr0G3vrkd8hZYkkx7-r08WgjKJeAKP9BxmhazRYggwE4SPLD0pK39PKHQ8SPHmIln9E504NHOUgvfyXlR-YCcjrjgxpyNMIEIkJ~9GsKxZ74qVO8fs5yAnRybXQHIlTEzzE3~eCQh6CxdDEWdD5TPw1gj9Nz-Nb3Qh9bk60vaeqiuvVuHyWTzhEHX95z4aSZT5-n2a9FVS90wDyQwxQfnwzkHP2ittDDX~cY8nKMToA__&Key-Pair-Id=APKAJQIC5BGSW7XXK7FQ)
-> The Backlinks view (fully expanded) is shown above with an example note 'eggs.md' open. You can see one link and 3 link candidates shown in the panel.
+![Backlinks Panel with Hover](https://org-dendron-public-assets.s3.amazonaws.com/images/vscode-hover-in-backlinks-panel.gif)
+> The Backlinks view (fully expanded) is shown above with an example note `dendron.ref.links` open. You can see 1 link and 1 link candidate shown in the panel.
 
+## Features
 
-## Commands 
+### Explicit and Candidate Backlinks
 
-#### Change Sort Order
-Change sort order of the backlinks:
-* Lexigraphically: sorts the backlinks by the name of the note.
-* By Update time: sorts the backlinks by descending update timestamp of the note (most recently updated notes first). 
+Dendron supports both explicit (wiklilinks, note refs) and candidate backlinks.
+ 
+A note has a candidate backlink if a different note has the name of the current note appear anywhere in its text. For example, if your current note is named `apple`, and in a different note called `recipes`, the word `apple` appears in the note body but is not explicitly linked, then `recipes` is said to have a link candidate to the `apple` note.
 
-Default: Lexigraphically. 
-
-#### Expand All/Collapse all 
-* Expand All: Expands all the backlinks in the backlink view.
-* Collapse All: Collapses all the backlinks in the backlink view.
-
-## Getting Started
-
-You can focus on the Backlinks view by:
-  - using the `Explorer: Focus on Backlinks View` command, or
-  - clicking on the Explorer icon in the VS Code Activity Bar and navigating to the Backlinks view at the bottom.
-  
-<!-- #TODO -->
-`Candidates` feature is currently disabled by default. In order to enable link candidates, add the following configuration in `dendron.yml`:
+This feature is currently disabled by default. In order to enable link candidates, add the following configuration in `dendron.yml`:
 
 ```yaml
 dev:
   enableLinkCandidates: true
 ```
 
-## Common components
-The view is structured to display information about backlinks as a tree.
+There is an icon next to each reference to indicate what kind of backlink it is. Explicit links have a link/chain icon. Candidates have the double plug / unplugged icon. See the sections below for more information on each item.
 
-When you first open the Backlinks view, you will be able to see a list of different notes. These are notes that have at least one backlink to the current note.
+If you click on an item anywhere other than the arrow, it will open that note in your editor. Furthermore, clicking on a link candidate item will open the note that contains the candidate, and convert the link candidate into a wikilink, turning it into `Linked` backlink.
 
-Each of the item in the list will have an arrow on the left. If you click on the arrow, the item will expand to display what type of backlinks are in that note.
+### Hover Context
 
-You will be able to see an item labeled `Linked` or `Candidates` depending on what type of backlinks that note has to the current note. See the sections below for more information on each item.
+You can hover over a backlink to see more context in the source note. The reference text will be highlighted. To make hover more responsive, we suggest modifying the following VSCode setting, which will make the hover appear sooner after you place your cursor on the link.  300 ms is a good setting for this feature, the default in VSCode is 1500 ms.
 
-If you click on an item anywhere other than the arrow, it will open that note in your editor.
+```yaml
+"workbench.hover.delay": 300
+```
 
+## Getting Started
 
-#### Linked backlinks
-If your current note has a linked backlink to it, you can see them in a subtree labeled `Linked` after expanding each source item.
+You can focus on the Backlinks view by:
+  - clicking on the Dendron icon in the VS Code Activity Bar and navigating to the Backlinks panel.
+  - using the `Explorer: Focus on Backlinks View` command
 
-Each `Linked` backlink will have a label that contains the text that comes before the link to give you a rough context of how the link was used in that location.
+### Options 
 
-Clicking on a linked item will open the note that contains the link.
+#### Change Sort Order
+Change sort order of the backlinks:
+* By Update time: sorts the backlinks by descending update timestamp of the note (most recently updated notes first). 
+* Lexigraphically: sorts the backlinks by the name of the note.
 
-#### Candidate backlinks
-If your current note has link candidates, you can see them in a subtree labeled `Candidates` after expanding each source item.
+Default: By Update Time.
 
-Each `Candidate` backlink will have a label that contains the text that comes before the link candidate to give you a rough context of how it was used in that location.
-
-Clicking on a link candidate item will open the note that contains the candidate, and convert the link candidate into a wikilink, turning it into `Linked` backlink.)
+#### Expand All/Collapse all 
+* Expand All: Expands all the backlinks in the backlink view.
+* Collapse All: Collapses all the backlinks in the backlink view.


### PR DESCRIPTION
## What does this PR do?

_Intended Release: v98_

Updates for Backlink Hover Feature

## What issues does this PR fix or reference?
<!-- Delete section or leave empty if no related GitHub Issue exists -->

- Fixes:
OR
- Relates to:

> **NOTE:** `Fixes` will close the ticket after merging. `Relates to:` will leave the ticket open after merging.

### Merge requirements satisfied

> For more information, visit the [Contributing Guide for Documentation](https://wiki.dendron.so/notes/b58801fc-43a9-4d42-a58b-eabc3e8538cb/)

- [ ] Check rendered output to ensure formatting is correct for renderings of wikilinks, note refs, tables, and images. `Dendron: Show Preview` can be used in your workspace to confirm the page renders as expected. Sometimes, `Dendron: Reload Index` needs to be ran if certain wikilinks aren't working as expected. (ignore this if contribution is made via the `Edit this page on GitHub` button from the published site)
- [ ] If this PR includes any refactoring (renaming notes, renaming headers, etc.), make sure that these changes were done via [Dendron Refactoring Commands](https://wiki.dendron.so/notes/srajljj10V2dl19nCSFiC/). This will ensure that any other impacted areas of the documentation, that link to or embed modified notes (via note references), are automatically updated.

Verify GitHub Actions tests are passing, which can be seen in the `Checks` tab of the PR:

- [ ] `URL validator` GitHub Action passes
- [ ] `Dendron site build` GitHub Action passes

> **NOTE:** If you are a new contributor, a maintainer will need to provide approval for GitHub Actions to run on your PRs.
