### PR TITLE
update tutorial frontmatter as per new convention

### DIFF
--- a/vault/tutorial.main.conclusion.md
+++ b/vault/tutorial.main.conclusion.md
@@ -1,9 +1,11 @@
 ---
 id: kyjfnf2rnc6vn71iyn9liz7
 title: Conclusion
-desc: ''
-updated: 1652123184798
+desc: ""
+updated: 1653980643031
 created: 1625564254964
+currentStep: 5
+totalSteps: 5
 nav_order: 4
 ---
 

--- a/vault/tutorial.main.linking-notes.md
+++ b/vault/tutorial.main.linking-notes.md
@@ -2,8 +2,10 @@
 id: khv6u4514vnvvy4njhctfru
 title: Linking Notes
 desc: Linking Notes
-updated: 1652280901513
+updated: 1653980618942
 created: 1625563999532
+currentStep: 3
+totalSteps: 5
 nav_order: 2
 ---
 

--- a/vault/tutorial.main.md
+++ b/vault/tutorial.main.md
@@ -2,8 +2,10 @@
 id: 4u6pv56mnt25d8l2wzfygu7
 title: Getting Started
 desc: ""
-updated: 1652280815854
+updated: 1653980552303
 created: 1608051264282
+currentStep: 0
+totalSteps: 5
 nav_order: 1.1
 ---
 

--- a/vault/tutorial.main.rich-formatting.md
+++ b/vault/tutorial.main.rich-formatting.md
@@ -2,8 +2,10 @@
 id: lxrp006mal1tfsd7nxmsobe
 title: Rich Formatting
 desc: ""
-updated: 1652291044262
+updated: 1653980630252
 created: 1625573403967
+currentStep: 4
+totalSteps: 5
 nav_order: 3
 ---
 

--- a/vault/tutorial.main.taking-notes.md
+++ b/vault/tutorial.main.taking-notes.md
@@ -4,8 +4,10 @@ title: Taking Notes
 desc: >-
   Creating notes, understanding hierarchy, and using Lookup to quickly find your
   notes
-updated: 1652388474734
+updated: 1653980609563
 created: 1625563944736
+currentStep: 2
+totalSteps: 5
 nav_order: 1
 ---
 

--- a/vault/tutorial.main.user-interface.md
+++ b/vault/tutorial.main.user-interface.md
@@ -2,8 +2,10 @@
 id: epmpyk2kjdxqyvflotan2vt
 title: User Interface
 desc: 1. User Interface
-updated: 1652280851960
+updated: 1653980572188
 created: 1625563862198
+currentStep: 1
+totalSteps: 5
 nav_order: 0
 ---
 

--- a/vault/tutorial.no-refactor.conclusion.md
+++ b/vault/tutorial.no-refactor.conclusion.md
@@ -1,9 +1,11 @@
 ---
 id: wmbd5xz40ohjb8rd5b737cq
 title: Conclusion
-desc: ''
-updated: 1652126817206
+desc: ""
+updated: 1653982042478
 created: 1625564254964
+currentStep: 5
+totalSteps: 5
 nav_order: 4
 ---
 

--- a/vault/tutorial.no-refactor.linking-notes.md
+++ b/vault/tutorial.no-refactor.linking-notes.md
@@ -2,8 +2,10 @@
 id: rjnqumna1ye82u9u76ni42k
 title: Linking Notes
 desc: Linking Notes
-updated: 1652280770996
+updated: 1653982014592
 created: 1625563999532
+currentStep: 3
+totalSteps: 5
 nav_order: 2
 ---
 

--- a/vault/tutorial.no-refactor.md
+++ b/vault/tutorial.no-refactor.md
@@ -2,8 +2,10 @@
 id: tbilk9to67d0dwgnjanj5ph
 title: Getting Started
 desc: ""
-updated: 1652280532205
+updated: 1653980839862
 created: 1608051264282
+currentStep: 0
+totalSteps: 5
 nav_order: 1.1
 ---
 

--- a/vault/tutorial.no-refactor.rich-formatting.md
+++ b/vault/tutorial.no-refactor.rich-formatting.md
@@ -2,8 +2,10 @@
 id: ie5x2bq5yj7uvenylblnhyr
 title: Rich Formatting
 desc: ""
-updated: 1652290942993
+updated: 1653982031426
 created: 1625573403967
+currentStep: 4
+totalSteps: 5
 nav_order: 3
 ---
 

--- a/vault/tutorial.no-refactor.taking-notes.md
+++ b/vault/tutorial.no-refactor.taking-notes.md
@@ -4,8 +4,10 @@ title: Taking Notes
 desc: >-
   Creating notes, understanding hierarchy, and using Lookup to quickly find your
   notes
-updated: 1652388453215
+updated: 1653982004089
 created: 1625563944736
+currentStep: 2
+totalSteps: 5
 nav_order: 1
 ---
 

--- a/vault/tutorial.no-refactor.user-interface.md
+++ b/vault/tutorial.no-refactor.user-interface.md
@@ -2,8 +2,10 @@
 id: kl6ndok3a1f14be6zv771c9
 title: User Interface
 desc: 1. User Interface
-updated: 1652280610218
+updated: 1653981984146
 created: 1625563862198
+currentStep: 1
+totalSteps: 5
 nav_order: 0
 ---
 

--- a/vault/tutorial.original.conclusion.md
+++ b/vault/tutorial.original.conclusion.md
@@ -2,8 +2,11 @@
 id: 5pz82kyfhp2whlzfldxmkzu
 title: Conclusion
 desc: ""
-updated: 1652279068668
+updated: 1653980815279
 created: 1652278009760
+currentStep: 5
+totalSteps: 5
+nav_order: 4
 ---
 
 **Congratulations!** You've completed the Dendron Tutorial 🙌.

--- a/vault/tutorial.original.linking-notes.md
+++ b/vault/tutorial.original.linking-notes.md
@@ -2,8 +2,11 @@
 id: 4do06cts1tme9yz7vfp46bu
 title: Linking Your Notes
 desc: Note Linking and your Knowledge Graph
-updated: 1652280371265
+updated: 1653980786307
 created: 1652278095382
+currentStep: 3
+totalSteps: 5
+nav_order: 2
 ---
 
 ### Links

--- a/vault/tutorial.original.md
+++ b/vault/tutorial.original.md
@@ -2,8 +2,11 @@
 id: y60h6laqi7w462zjp3jyqtt
 title: Tutorial
 desc: "Tutorial Home Page"
-updated: 1652287311642
+updated: 1653980718180
 created: 1652278009766
+currentStep: 0
+totalSteps: 5
+nav_order: 1.1
 ---
 
 ## Welcome to Dendron

--- a/vault/tutorial.original.rich-formatting.md
+++ b/vault/tutorial.original.rich-formatting.md
@@ -2,8 +2,11 @@
 id: kzry3qcy2y4ey1jcf1llajg
 title: Rich Formatting
 desc: "Text Formatting, Images, Formulas, and Diagrams"
-updated: 1652280413439
+updated: 1653980802473
 created: 1652278089118
+currentStep: 4
+totalSteps: 5
+nav_order: 3
 ---
 
 Dendron supports an extended Markdown syntax, which provides a lot of options for rich formatting. Take a look at some examples in this note to see what's possible. Have the preview pane opened (`Dendron: Show Preview`) to see how these will get rendered.

--- a/vault/tutorial.original.taking-notes.md
+++ b/vault/tutorial.original.taking-notes.md
@@ -2,8 +2,11 @@
 id: mycf53kz1r7swcttcobwbdl
 title: Taking Notes
 desc: ""
-updated: 1652388439051
+updated: 1653980773142
 created: 1652278083208
+currentStep: 2
+totalSteps: 5
+nav_order: 1
 ---
 
 ### Create a Note

--- a/vault/tutorial.original.user-interface.md
+++ b/vault/tutorial.original.user-interface.md
@@ -2,8 +2,11 @@
 id: ks3b4u7gnd6yiw68qu6ba4m
 title: Navigation Basics
 desc: ""
-updated: 1652279527689
+updated: 1653980753187
 created: 1652278075049
+currentStep: 1
+totalSteps: 5
+nav_order: 0
 ---
 
 Let's do a brief overview on how to navigate the Dendron UI.


### PR DESCRIPTION
## What does this PR do?
- Updates tutorial frontmatter to contain `currentStep` and `totalSteps` as per new convention

## What issues does this PR fix or reference?
- Relates to: dendronhq/dendron#3009

### Merge requirements satisfied

> For more information, visit the [Contributing Guide for Documentation](https://wiki.dendron.so/notes/b58801fc-43a9-4d42-a58b-eabc3e8538cb/)

- [ ] Check rendered output to ensure formatting is correct for renderings of wikilinks, note refs, tables, and images. `Dendron: Show Preview` can be used in your workspace to confirm the page renders as expected. Sometimes, `Dendron: Reload Index` needs to be ran if certain wikilinks aren't working as expected. (ignore this if contribution is made via the `Edit this page on GitHub` button from the published site)
- [ ] If this PR includes any refactoring (renaming notes, renaming headers, etc.), make sure that these changes were done via [Dendron Refactoring Commands](https://wiki.dendron.so/notes/srajljj10V2dl19nCSFiC/). This will ensure that any other impacted areas of the documentation, that link to or embed modified notes (via note references), are automatically updated.

Verify GitHub Actions tests are passing, which can be seen in the `Checks` tab of the PR:

- [ ] `URL validator` GitHub Action passes
- [ ] `Dendron site build` GitHub Action passes

> **NOTE:** If you are a new contributor, a maintainer will need to provide approval for GitHub Actions to run on your PRs.
