### PR TITLE
Update dendron.ref.cli.md

### DIFF
--- a/vault/dendron.ref.cli.md
+++ b/vault/dendron.ref.cli.md
@@ -33,16 +33,25 @@ Use doctor to perform specific fixes over your notes.
 doctor helps you fix your notes
 
 Options:
-  --version     Show version number                                    [boolean]
-  --help        Show help                                              [boolean]
-  --wsRoot      location of workspace                                 [required]
-  --enginePort  If set, connecto to running engine. If not set, create new
-                instance of Dendron Engine
-  --action      what action the doctor should take
-                            [array] [choices: "h1ToTitle", "h1ToH2"]
-  --query       run doctor over a query                                 [string]
-  --limit       limit num changes                                       [number]
-  --dryRun      dry run                                                [boolean]
+  --version         Show version number                                [boolean]
+  --help            Show help                                          [boolean]
+  --wsRoot          location of workspace
+  --vault           name of vault
+  --quiet           don't print output to stdout
+  --enginePort      If set, connect to to running engine. If not set, create new
+                    instance of Dendron Engine
+  --attach          Use existing engine instead of spawning a new one
+  --useLocalEngine  If set, use in memory engine instead of connecting to a
+                    server                                             [boolean]
+  --action          what action the doctor should take
+      [string] [choices: "fixFrontmatter", "h1ToTitle", "h1ToH2", "removeStubs",
+              "createMissingLinkedNotes", "regenerateNoteId", "findBrokenLinks",
+           "fixRemoteVaults", "fixAirtableMetadata", "addMissingDefaultConfigs",
+                    "removeDeprecatedConfigs", "fixSelfContainedVaultsInConfig"]
+  --query           run doctor over a query                             [string]
+  --limit           limit num changes                                   [number]
+  --dryRun          dry run                                            [boolean]
+  --podId           podId used to export note(s) to Airtable            [string]
 ```
 
 #### available actions
@@ -71,16 +80,18 @@ The CLI will also write out `.dendron.*` [[metadata files|dendron._ref.layout#fi
 
 
 ```sh
-launch instance of Dendron engine
+launch instance of dendron engine
 
 Options:
-  --version  Show version number                                       [boolean]
-  --help     Show help                                                 [boolean]
-  --wsRoot   location of workspace
-  --vault    name of vault
-  --quiet    don't print output to stdout
-  --port     port to launch server                                      [number]
-  --init     initialize server                                         [boolean]
+  --version      Show version number                                   [boolean]
+  --help         Show help                                             [boolean]
+  --wsRoot       location of workspace
+  --vault        name of vault
+  --quiet        don't print output to stdout
+  --port         port to launch server                                  [number]
+  --init         initialize server                                     [boolean]
+  --noWritePort  don't write the port to a file                        [boolean]
+  --fast         launch engine without indexing                        [boolean]
 ```
 
 
@@ -92,43 +103,39 @@ dendron launchEngineServer --wsRoot ~/Dendron/ --port 3005
 
 ## Publishing Commands
 
-### buildSite
+### publish
 
 ```bash
-dendron buildSite
+dendron publish <cmd>
 
-build notes for publication using 11ty
+commands for publishing notes
+
+Positionals:
+  cmd  a command to run
+                 [string] [required] [choices: "init", "build", "dev", "export"]
 
 Options:
-  --version         Show version number                                [boolean]
-  --help            Show help                                          [boolean]
-  --wsRoot          location of workspace                             
-  --enginePort      If set, connecto to running engine. If not set, create new
-                    instance of Dendron Engine
-  --serve           serve over local http server      [boolean] [default: false]
-  --stage           serve over local http server
-                                       [choices: "dev", "prod"] [default: "dev"]
-  --output          if set, override output from config.yml             [string]
-  --custom11tyPath  if set, path to custom 11ty installation            [string]
+  --version    Show version number                                     [boolean]
+  --help       Show help                                               [boolean]
+  --wsRoot     location of workspace
+  --vault      name of vault
+  --quiet      don't print output to stdout
+  --dest       override where nextjs-template is located                [string]
+  --attach     use existing dendron engine instead of spawning a new one
+                                                                       [boolean]
+  --noBuild    skip building notes                    [boolean] [default: false]
+  --overrides  override existing siteConfig properties                  [string]
 ```
 
-#### Using a different port
+See [[dendron.topic.publish]] for more info.
 
-![[dendron.topic.publish-legacy.configuration#previewport,1:#*]]
+#### examples
 
-#### Connect to Open Workspace
+- build and preview the site locally
 
-Normally, this command will spawn a new Dendron Engine that indexes your notes before building them for publication. You can skip this initial indexing if you have a current Dendron workspace running. 
-
-In that case, the CLI can connect to the current engine instead of starting a new one using the following command. 
-
-```bash ^Vn7zB1oSBz07
-cd {root/of/workspace}
-# .dendron.port has the port of the current running workspace
-npx dendron buildSite --wsRoot . --stage dev --serve --enginePort `cat .dendron.port`
+```bash
+dendron publish dev
 ```
-
-### Using a custom port
 
 
 ## Pod Commands
@@ -145,7 +152,7 @@ dendron vault <cmd>
 vault related commands
 
 Positionals:
-  cmd  a command to run                  [string] [required] [choices: "create"]
+  cmd  a command to run       [string] [required] [choices: "create", "convert"]
 
 Options:
   --version         Show version number                                [boolean]
@@ -155,10 +162,16 @@ Options:
   --quiet           don't print output to stdout
   --enginePort      If set, connect to to running engine. If not set, create new
                     instance of Dendron Engine
+  --attach          Use existing engine instead of spawning a new one
   --useLocalEngine  If set, use in memory engine instead of connecting to a
                     server                                             [boolean]
   --vaultPath       path to vault                            [string] [required]
   --noAddToConfig   if set, don't add vault to dendron.yml             [boolean]
+  --remoteUrl       If converting to a remote vault, URL of the remote to use.
+                    Like https://github.com/dendronhq/dendron-site.git or
+                    git@github.com:dendronhq/dendron-site.git           [string]
+  --type            If converting a vault, what type of vault to convert it to.
+                                           [string] [choices: "remote", "local"]
 ```
 
 ### Actions
@@ -171,6 +184,15 @@ Create a vault. By default, also add entry to `dendron.yml`. If no `dendorn.yml`
 dendron vault create --vaultPath kevin-test --wsRoot .
 ```
 
+<!-- #### Convert
+
+Convert a vault between `remote` and `local`.
+
+```sh
+dendron vault convert --vaultPath kevin-test --wsRoot . --type remote --remoteURL https://github.com/dendronhq/dendron-site.git
+```
+-->
+
 ## Workspace Command
 
 
@@ -180,7 +202,9 @@ dendron workspace <cmd>
 workspace related commands
 
 Positionals:
-  cmd  a command to run            [string] [required] [choices: "pull", "push"]
+  cmd  a command to run
+           [string] [required] [choices: "pull", "push", "addAndCommit", "sync",
+                                                  "removeCache", "init", "info"]
 
 Options:
   --version         Show version number                                [boolean]
@@ -190,6 +214,7 @@ Options:
   --quiet           don't print output to stdout
   --enginePort      If set, connect to to running engine. If not set, create new
                     instance of Dendron Engine
+  --attach          Use existing engine instead of spawning a new one
   --useLocalEngine  If set, use in memory engine instead of connecting to a
                     server                                             [boolean]
 ```
@@ -217,6 +242,11 @@ Run `git add . && git commit` on all vaults inside the workspace
 #### sync
 
 Run `addAndCommit`, `pull`, and `push` on all vaults inside the workspace. This follows the same configuration as the `Workspace: Sync` command in the extension, see [[Workspace Sync|dendron.topic.workspace#Workspace: Sync]] for details.
+
+<!-- #### removeCache
+
+#### info 
+-->
 
 ## Dev Command
 


### PR DESCRIPTION
Updated to include all new flags for the commands based on output on `--help` call, and replaced legacy publishing command with new nextjs one. 

Link to publish page not actually tested as I made this change in the github GUI.

Note that I haven't tested the example for the `convert` action on the vault commands section, and did not know what to put for the info and removeCache options for `workspace` so have left these headers commented out for now until they can be populated.

## What does this PR do?
Updates the dendron.ref.cli note to reflect he current flags and publishing options.

## What issues does this PR fix or reference?

### Merge requirements satisfied

> For more information, visit the [Contributing Guide for Documentation](https://wiki.dendron.so/notes/b58801fc-43a9-4d42-a58b-eabc3e8538cb/)

- [ ] Check rendered output to ensure formatting is correct for renderings of wikilinks, note refs, tables, and images. `Dendron: Show Preview` can be used in your workspace to confirm the page renders as expected. Sometimes, `Dendron: Reload Index` needs to be ran if certain wikilinks aren't working as expected. (ignore this if contribution is made via the `Edit this page on GitHub` button from the published site)
- [ ] If this PR includes any refactoring (renaming notes, renaming headers, etc.), make sure that these changes were done via [Dendron Refactoring Commands](https://wiki.dendron.so/notes/srajljj10V2dl19nCSFiC/). This will ensure that any other impacted areas of the documentation, that link to or embed modified notes (via note references), are automatically updated.

Verify GitHub Actions tests are passing, which can be seen in the `Checks` tab of the PR:

- [ ] `URL validator` GitHub Action passes
- [ ] `Dendron site build` GitHub Action passes

> **NOTE:** If you are a new contributor, a maintainer will need to provide approval for GitHub Actions to run on your PRs.
