### PR TITLE
update cli template and enforce via schema

### DIFF
--- a/vault/dendron.schema.yml
+++ b/vault/dendron.schema.yml
@@ -47,10 +47,11 @@ schemas:
       desc: concepts for this feature
     - pattern: config
       desc: configuration for this feature
-    - pattern: "*"
-      title: sub feature or component
     - pattern: cli
       desc: CLI commands for this feature
+      template: templates.cli
+    - pattern: "*"
+      title: sub feature or component
 - id: template
   template:
     id: dendron.template.example

--- a/vault/templates.cli.md
+++ b/vault/templates.cli.md
@@ -2,12 +2,41 @@
 id: 39menlcx30lpo1ci4px7aew
 title: CLI
 desc: ''
-updated: 1654385553923
+updated: 1655414733603
 created: 1654385553923
 templateId: "39menlcx30lpo1ci4px7aew"
 ---
 ## Summary
 
-## Options
+{{fm.desc}}
+
+## Usage
+
+```sh
+example --help output
+
+Options:
+  --version         Show version number                                [boolean]
+    ...
+```
+
+### Options
+<!-- Key value list for any non-obvious options, with sub lists as need for allowed values and definitions of them e.g.
+    - `--output`: controls how note is formatted
+        - values: `json|md_gfm|md_dendron`
+            - `json`: JSON output
+            - `md_dendron`: dendron markdown
+            - `md_gfm`: github flavored markdown 
+-->
+
+### Actions
+<!-- Use level 4 headers per action, describing the purpose of each action -->
 
 ## Examples
+<!-- Bullet description of the example followed by the code, e.g. 
+    - Import notes from FilePod
+
+    ```sh
+    dendron importPod --podId dendron.markdown --wsRoot . 
+    ```
+-->

--- a/vault/templates.cli.md
+++ b/vault/templates.cli.md
@@ -2,7 +2,7 @@
 id: 39menlcx30lpo1ci4px7aew
 title: CLI
 desc: ''
-updated: 1655414733603
+updated: 1655631320910
 created: 1654385553923
 templateId: "39menlcx30lpo1ci4px7aew"
 ---
@@ -20,17 +20,11 @@ Options:
     ...
 ```
 
-### Options
-<!-- Key value list for any non-obvious options, with sub lists as need for allowed values and definitions of them e.g.
-    - `--output`: controls how note is formatted
-        - values: `json|md_gfm|md_dendron`
-            - `json`: JSON output
-            - `md_dendron`: dendron markdown
-            - `md_gfm`: github flavored markdown 
--->
+### Commands
+<!-- Remove if not required: Use level 4 headers per command, describing the purpose of each command -->
 
-### Actions
-<!-- Use level 4 headers per action, describing the purpose of each action -->
+### Options
+<!-- Use level 4 headers per option, describing the purpose of each option, then any values and their meaning in a list if required-->
 
 ## Examples
 <!-- Bullet description of the example followed by the code, e.g. 


### PR DESCRIPTION
## What does this PR do?
Adds a standard `cli` template to the `topic` hierarchy, with examples in each section of what needs to be populated.

Only thing I couldn't get to work was to have `{{fm.desc}}` to remain populated once the template was used, as the new note is created without a description, this is ran dynamically and populated as empty, instead of remaining there...

### Merge requirements satisfied

> For more information, visit the [Contributing Guide for Documentation](https://wiki.dendron.so/notes/b58801fc-43a9-4d42-a58b-eabc3e8538cb/)

- [x] Check rendered output to ensure formatting is correct for renderings of wikilinks, note refs, tables, and images. `Dendron: Show Preview` can be used in your workspace to confirm the page renders as expected. Sometimes, `Dendron: Reload Index` needs to be ran if certain wikilinks aren't working as expected. (ignore this if contribution is made via the `Edit this page on GitHub` button from the published site)
- [x] If this PR includes any refactoring (renaming notes, renaming headers, etc.), make sure that these changes were done via [Dendron Refactoring Commands](https://wiki.dendron.so/notes/srajljj10V2dl19nCSFiC/). This will ensure that any other impacted areas of the documentation, that link to or embed modified notes (via note references), are automatically updated.

Verify GitHub Actions tests are passing, which can be seen in the `Checks` tab of the PR:

- [ ] `URL validator` GitHub Action passes
- [x] `Dendron site build` GitHub Action passes

> **NOTE:** If you are a new contributor, a maintainer will need to provide approval for GitHub Actions to run on your PRs.
