### PR TITLE
forcing cli to be v 0.100.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,6 @@
         "dendron": "dendron-cli"
     },
     "dependencies": {
-        "@dendronhq/dendron-cli": "^0.97.0"
+        "@dendronhq/dendron-cli": "^0.100.0"
     }
 }


### PR DESCRIPTION
forcing cli to be v 0.100.0 in package.json.  This should be needed for the new banner logic.