### PR TITLE
Note Traits Revamp

### DIFF
--- a/vault/dendron.ref.config.workspace.md
+++ b/vault/dendron.ref.config.workspace.md
@@ -2,7 +2,7 @@
 id: 3i4ABJutl7NGeXRHTnUEC
 title: Workspace
 desc: ''
-updated: 1638518870049
+updated: 1655718960854
 created: 1634646633536
 ---
 
@@ -97,7 +97,7 @@ Use [luxon style formatting](https://moment.github.io/luxon/#/formatting)
 ### addBehavior
 
 Sets the strategy for adding new journal notes.
-This only applies to regular journal notes but not to [[Details|dendron.topic.daily-journal-note#details]] notes.
+This only applies to regular journal notes but not to [[Daily Journal Notes|dendron.topic.daily-journal-note#details]]. For possible options, see [[addBehavior options|dendron://dendron.dendron-site/dendron.topic.special-notes#defaultnodetypeaddbehavior]]
 
 - default: "childOfDomain"
 
@@ -120,7 +120,7 @@ Use [luxon style formatting](https://moment.github.io/luxon/#/formatting)
 
 ### addBehavior
 
-Sets the strategy for adding new scratch notes.
+Sets the strategy for adding new scratch notes. For possible options, see [[addBehavior options|dendron://dendron.dendron-site/dendron.topic.special-notes#defaultnodetypeaddbehavior]]
 
 - default: "asOwnDomain"
 

--- a/vault/dendron.topic.traits.api.md
+++ b/vault/dendron.topic.traits.api.md
@@ -2,7 +2,7 @@
 id: oOIEFJc6DTgS71mmh89WQ
 title: API
 desc: ''
-updated: 1639157690633
+updated: 1655883676296
 created: 1638844803983
 ---
 
@@ -43,40 +43,30 @@ See [[Creation Properties|dendron://dendron.dendron-site/dendron.topic.traits.ap
 
 A string containing the modified title.
 
+### setTemplate
 
-## Example
+When implemented, a template will be applied to the note being created.
 
-This shows an example implementation of a note trait. Note, this is just the default template that is applied when you create a new note trait.
+#### Arguments
 
-```javascript
-module.exports = {
-  /**
-   * Specify behavior to modify the name of the note. If
-   * promptUserForModification is true, the modified name will appear in a
-   * lookup control to allow the user to further edit the note name before
-   * confirming.
-   */
-  OnWillCreate: {
-    setNameModifier(props) {
-      return {
-        name: [props.currentNoteName, props.selectedText, props.clipboard].join(','),
-        promptUserForModification: true
-      };
-    }
-  },
-  /**
-   * Specify behavior for altering the title of the note when it is created.
-   */
-  OnCreate: {
-    setTitle(props) {
-      return [props.currentNoteName, props.selectedText, props.clipboard].join(',');
-    }
-  }
-}
-```
+_None_
+
+#### What Needs to be Returned
+
+The name of the note to use as the template. This should be another note in your workspace. Examples: `root`, `templates.meeting-note`.
+
+![[Examples|dendron://dendron.dendron-site/dendron.topic.traits.examples]]
 
 ## Creation Properties
 
 - currentNoteName - for `setNameModifier()`, this contains the name of the Dendron note that is currently in focus in the editor. If no note is in focus, then this returns `undefined`.  For `setTitle()`, this contains the note name returned from `setNoteModifier()`.
 - selectedText - contains the text that has been highlighted in the current editor of a Dendron Note. If no text is highlighted, or if the highlighted text is not in a Dendron note, this returns `undefined`.
 - clipboard - contains any text currently on the clipboard, or `undefined` if there is no text.
+
+## Included Modules
+
+[Lodash](https://lodash.com/docs) and [Luxon](https://moment.github.io/luxon/api-docs/index.html) modules are accessible in the code you write for your traits. There is no need to include any import statements.
+
+## Examples
+
+For example Javascript implementations of Traits, see the [[examples|dendron://dendron.dendron-site/dendron.topic.traits.examples]] hierarchy.

--- a/vault/dendron.topic.traits.examples.md
+++ b/vault/dendron.topic.traits.examples.md
@@ -1,0 +1,13 @@
+---
+id: qw0iw9ymf725eoqnptzafd2
+title: Examples
+desc: ''
+updated: 1655883851061
+created: 1655717385086
+---
+
+The child notes of this hierarchy are example Javascript implementations to help you get started with creating your own note traits. You don't need to be a Javascript expert to be able to get started! Even with some small modifications, you can likely get to where you need and utilize the power of note traits.
+
+## Example Traits
+- [[Note with Date Hierarchy|dendron://dendron.dendron-site/dendron.topic.traits.examples.note-with-date-hierarchy]]
+- [[Using Hierarchy Position|dendron://dendron.dendron-site/dendron.topic.traits.examples.using-hierarchy-position]]

--- a/vault/dendron.topic.traits.examples.note-with-date-hierarchy.md
+++ b/vault/dendron.topic.traits.examples.note-with-date-hierarchy.md
@@ -1,0 +1,54 @@
+---
+id: kwgbkl58xka0zsib8uhhkfw
+title: Note with Date Hierarchy
+desc: ''
+updated: 1655718090379
+created: 1655717424162
+---
+
+## Summary
+
+This trait closely mirrors the functionality of [[Journal Notes|dendron://dendron.dendron-site/dendron.topic.special-notes#journal-note]], but allows you to put the notes under a different domain. This example creates a "planning" note with the following behavior:
+- uses 'planning' as the domain, followed by a dated hierarchy in the format (yyyy.MM.dd)
+- changes the title of the note to a format like `2020-07-14`
+- Applies a template to the note
+
+## Trait Definition
+
+_planning-trait.js_:
+
+```javascript
+module.exports = {
+  OnWillCreate: {
+    /**
+     * This example sets a prefix of 'planning', and then adds a date hierarchy
+     * using the luxon module.
+     */
+    setNameModifier() {
+      // This example sets a prefix of 'planning', and then adds a date
+      // hierarchy using the luxon module.
+      return {
+        name: "planning." + luxon.DateTime.local().toFormat("yyyy.MM.dd"),
+        promptUserForModification: true,
+      };
+    },
+  },
+  OnCreate: {
+    setTitle(props) {
+      // This example will use the currentNoteName property, extract the
+      // yyyy.MM.dd date portion of the note name, and then reformat it with
+      // dashes.
+      return props.currentNoteName.split(".").slice(-3).join("-");
+    },
+    /**
+     * Apply a template to each note. NOTE: If you want to use this code, you
+     * will need a note file called `templates.planning-template.md` in your
+     * Dendron workspace.
+     */
+    setTemplate: () => {
+      return "templates.planning-template";
+    },
+  },
+};
+
+```

--- a/vault/dendron.topic.traits.examples.using-hierarchy-position.md
+++ b/vault/dendron.topic.traits.examples.using-hierarchy-position.md
@@ -1,0 +1,64 @@
+---
+id: dws0n0eez2i3ln5as6eur0i
+title: Using Hierarchy Position
+desc: ''
+updated: 1655882859665
+created: 1655719097688
+---
+
+## Summary
+
+This trait demonstrates how you can use your current hierarchy position to create a new note, similar to how the [[childOfDomain addBehavior|dendron://dendron.dendron-site/dendron.topic.special-notes#defaultnodetypeaddbehavior]] works for special notes like Journal notes or scratch notes. In fact, all of the add-behaviors can be implemented with the note trait system.
+
+This example creates a 'weekly-assignments' type of note with the following behavior:
+- re-uses the current domain. For example, if you're currently viewing a note `physics.lectures.quantum-mechanics`, then the new note's name will start with `physics.assignments.*`
+- Appends the year + week-year.
+- Applies a template to the note
+
+Because this note trait falls under your current domain, you can then re-use this trait to create notes to track your weekly assignments in your other hierarchies, i.e.  `computer-science`, `biology`, `english`, etc.
+
+## Trait Definition
+
+_weekly-assignments-trait.js_:
+
+```javascript
+module.exports = {
+  OnWillCreate: {
+    /**
+     * This example takes the domain of the current note (the first segment of the hierarchy), 
+     * adds 'assignments', followed by the year and the week number
+     */
+    setNameModifier(props) {
+      const nameComponents = [
+        props.currentNoteName.split('.')[0],
+        "assignments",
+        luxon.DateTime.local().year.toString(),
+        luxon.DateTime.local().weekNumber.toString()
+      ];
+
+      return {
+        name: nameComponents.join('.'),
+        promptUserForModification: true,
+      };
+    },
+  },
+  OnCreate: {
+    setTitle(props) {
+      const domain = props.currentNoteName.split('.')[0];
+    
+      // Lodash '_' is available if needed
+      return `${_.capitalize(domain)} Week ${props.currentNoteName.split(".").slice(-1)} Assignments` 
+
+    },
+    /**
+     * Apply a template to each note. NOTE: If you want to use this code, you
+     * will need a note file called `templates.planning-template.md` in your
+     * Dendron workspace.
+     */
+    setTemplate: () => {
+      return "templates.assignments-template";
+    },
+  },
+};
+```
+

--- a/vault/dendron.topic.traits.md
+++ b/vault/dendron.topic.traits.md
@@ -2,8 +2,118 @@
 id: bdZhT3nF8Yz3WDzKp7hqh
 title: Traits
 desc: ''
-updated: 1638843091031
+updated: 1655883537966
 created: 1638842998292
 ---
 
-Dendron's trait system allows you to create custom behavior and apply it to certain notes.
+## Summary
+
+Dendron's trait system allows you to create custom behavior and apply it to certain notes. An analogy for note traits is a typed system for programming languages.
+
+_Note: This is a [[germ stage|dendron://dendron.dendron-site/tags.stage.germ]] feature that may have breaking changes in future versions of Dendron_
+!
+
+## Use Cases
+- You want to have some of the characteristics of Dendron's built-in [[journal notes|dendron://dendron.dendron-site/dendron.topic.special-notes#journal-note]] or [[scratch notes|dendron://dendron.dendron-site/dendron.topic.special-notes#scratch-note]], but you want to customize the behavior yourself
+- You want to apply a template to notes when they are created instead of defining a [[schema template|dendron://dendron.dendron-site/dendron.topic.templates.schema-template]].
+
+## Getting Started
+
+This example will show you how you can create your own note traits and apply them to your new notes.  In this example, we'll create a trait that will modify the name and title of the note automatically when you create a new note.
+
+### 1. Create a new Note Trait
+
+Run the command `Dendron: Register Note Trait`. Give your new trait a unique name.  In this example, we'll call the trait professional-connections. Hit `Enter` and a `professional-connections.js` file will appear in your editor. This is where you define your custom trait logic.
+
+### 2. Add the trait behavior
+
+Add in Javascript code to have custom settings when creating the note name and the note title.
+
+> ❗️ Note: The API's here may have breaking changes in future iterations. More functionality will also be exposed to note traits in the future.
+
+For now, replace the contents of `professional-connections.js` with the code below.  To see documentation of how the API works, you can take a look [[here|dendron.topic.traits.api]].
+
+This code will behave as follows:
+
+For the note name:
+- Prepend the current year and date to the name to form a year/month hierarchy
+- If any highlighted text of a Dendron Note, use that for the note name
+- Else, if there are clipboard contents, use that for the note name
+- Otherwise, just use a placeholder 'John Doe'
+- Allows the user to further modify the note name before confirming
+
+For the note title:
+- Extract from the note the person's name, and capitalize it.
+
+```javascript
+module.exports = {
+  /**
+   * Creates a note name with a year.month.name format.
+   */
+  OnWillCreate: {
+    setNameModifier(props) {
+
+      // placeholder name:
+      let nameModifier = "John Doe";
+
+      // Try to get the name first from selected Text, and secondly from the clipboard
+      if (props.selectedText) {
+        nameModifier = props.selectedText
+      }
+      else if (props.clipboard) {
+        nameModifier = props.clipboard;
+      }
+
+      // Add a date component with year and month
+      const curDate = new Date();
+      const year = curDate.getFullYear();
+      const month = curDate.getMonth() + 1; // getMonth is 0 indexed
+
+      return {
+        name: [year, month, nameModifier].join('.'),
+        promptUserForModification: true
+      };
+    }
+  },
+  /**
+   * Extracts the name component of the note title and capitalizes it
+   */
+  OnCreate: {
+    setTitle(props) {
+      const fName = props.currentNoteName;
+
+      if (fName.includes(".") && fName.lastIndexOf(".") < fName.length) {
+        const namepart = fName.substring(fName.lastIndexOf(".") + 1);
+        const capitalized = namepart.split('-').map(element => element[0].toUpperCase() + element.substring(1));
+
+        return capitalized.join(' ');
+      }
+      else {
+        return fName;
+      }
+    }
+  }
+}
+```
+
+### 3. Create a new note with the Trait applied
+
+Run the command `Dendron: Create Note With Custom Trait`. Select your trait, `professional-connections`. This will bring up a lookup command with pre-filled contents in the input box for the note name. Click confirm. You should see a new note get generated, with the title modified automatically applied.
+
+### 4. (Optional) Create a shortcut for your trait
+
+You can also assign a VSCode keybinding to create a note with your trait applied, similar to how there are keybindings for Scratch Notes and Journal Notes.
+
+For every note trait, a command is registered called `dendron.customCommand.your-note-trait-name`.  So in this example, the command would be `dendron.customCommand.professional-connections`. To create a VSCode keybinding: 
+
+1. Run the VSCode Command `Preferences: Open Keyboard Shortcuts (JSON)`
+1. Add the following entry to the bottom of your `keybindings.json` file, with the shortcut key combo of your choice:
+
+```json
+  {
+    "key": "cmd+j q",
+    "command": "dendron.customCommand.your-note-trait-name"
+  },
+```
+
+_Note: The name of this command may change in future versions of Dendron_


### PR DESCRIPTION
## What does this PR do?

Improved Docs for Note Traits that also covers new functionality.

**Public Announcement**

We've made some improvements to note traits to make them easier to use. If you've ever wanted to further customize the way Journal and Scratch Notes work or if you've wanted to add your own types, try it out! Changes include:
- Improved docs and examples (TODO: Add links to docs from this PR when published)
- the 'Configure Note Traits` command lets you edit your existing traits more easily 
- No more need to reload window to apply your changes - after changing your trait file, you can test out the changes immediately
- Better feedback if you have any Javascript errors in your traits code
- Lodash and Luxon modules available to help with date and string operations.