### PR TITLE
fixing some note trait documentation errors

### DIFF
--- a/vault/dendron.topic.traits.examples.md
+++ b/vault/dendron.topic.traits.examples.md
@@ -1,8 +1,8 @@
 ---
 id: qw0iw9ymf725eoqnptzafd2
-title: Examples
+title: Trait Examples
 desc: ''
-updated: 1655883851061
+updated: 1656468391128
 created: 1655717385086
 ---
 

--- a/vault/dendron.topic.traits.md
+++ b/vault/dendron.topic.traits.md
@@ -2,7 +2,7 @@
 id: bdZhT3nF8Yz3WDzKp7hqh
 title: Traits
 desc: ''
-updated: 1655883537966
+updated: 1656468624871
 created: 1638842998292
 ---
 
@@ -10,8 +10,7 @@ created: 1638842998292
 
 Dendron's trait system allows you to create custom behavior and apply it to certain notes. An analogy for note traits is a typed system for programming languages.
 
-_Note: This is a [[germ stage|dendron://dendron.dendron-site/tags.stage.germ]] feature that may have breaking changes in future versions of Dendron_
-!
+_Note: This is a [[germ stage|dendron://dendron.dendron-site/tags.stage.germ]] feature that may have breaking changes in future versions of Dendron!_
 
 ## Use Cases
 - You want to have some of the characteristics of Dendron's built-in [[journal notes|dendron://dendron.dendron-site/dendron.topic.special-notes#journal-note]] or [[scratch notes|dendron://dendron.dendron-site/dendron.topic.special-notes#scratch-note]], but you want to customize the behavior yourself
@@ -23,7 +22,7 @@ This example will show you how you can create your own note traits and apply the
 
 ### 1. Create a new Note Trait
 
-Run the command `Dendron: Register Note Trait`. Give your new trait a unique name.  In this example, we'll call the trait professional-connections. Hit `Enter` and a `professional-connections.js` file will appear in your editor. This is where you define your custom trait logic.
+Run the command `Dendron: Configure Note Traits`. Give your new trait a unique name.  In this example, we'll call the trait professional-connections. Hit `Enter` and a `professional-connections.js` file will appear in your editor. This is where you define your custom trait logic.
 
 ### 2. Add the trait behavior
 
@@ -117,3 +116,7 @@ For every note trait, a command is registered called `dendron.customCommand.your
 ```
 
 _Note: The name of this command may change in future versions of Dendron_
+
+### More Examples
+
+For more examples including how to replicate [[journal|dendron://dendron.dendron-site/dendron.topic.special-notes#journal-note]] or [[scratch note|dendron://dendron.dendron-site/dendron.topic.special-notes#scratch-note]] behavior, see the [[examples|dendron://dendron.dendron-site/dendron.topic.traits.examples]] note.

--- a/vault/dendron.topic.traits.quickstart.md
+++ b/vault/dendron.topic.traits.quickstart.md
@@ -2,7 +2,7 @@
 id: EQoaBI8A0ZcswKQC3UMpO
 title: Quickstart
 desc: ''
-updated: 1639157723576
+updated: 1656468834513
 created: 1638843110902
 ---
 
@@ -10,81 +10,4 @@ This example will show you how you can create your own note traits and apply the
 
 ![[dendron://dendron.dendron-site/tags.stage.germ]]
 
-### Create a new Note Trait
-
-Run the command `Dendron: Register Note Trait`. Give your new trait a unique name.  In this example, we'll call the trait professional-connections. Hit `Enter` and a `professional-connections.js` file will appear in your editor. This is where you define your custom trait logic.
-
-### Add the trait behavior
-
-Add in Javascript code to have custom settings when creating the note name and the note title.
-
-> ❗️ Note: The API's here may have breaking changes in future iterations. More functionality will also be exposed to note traits in the future.
-
-For now, replace the contents of `professional-connections.js` with the code below.  To see documentation of how the API works, you can take a look [[here|dendron.topic.traits.api]].
-
-This code will behave as follows:
-
-For the note name:
-- Prepend the current year and date to the name to form a year/month hierarchy
-- If any highlighted text of a Dendron Note, use that for the note name
-- Else, if there are clipboard contents, use that for the note name
-- Otherwise, just use a placeholder 'John Doe'
-- Allows the user to further modify the note name before confirming
-
-For the note title:
-- Extract from the note the person's name, and capitalize it.
-
-```javascript
-module.exports = {
-  /**
-   * Creates a note name with a year.month.name format.
-   */
-  OnWillCreate: {
-    setNameModifier(props) {
-
-      // placeholder name:
-      let nameModifier = "John Doe";
-
-      // Try to get the name first from selected Text, and secondly from the clipboard
-      if (props.selectedText) {
-        nameModifier = props.selectedText
-      }
-      else if (props.clipboard) {
-        nameModifier = props.clipboard;
-      }
-
-      // Add a date component with year and month
-      const curDate = new Date();
-      const year = curDate.getFullYear();
-      const month = curDate.getMonth() + 1; // getMonth is 0 indexed
-
-      return {
-        name: [year, month, nameModifier].join('.'),
-        promptUserForModification: true
-      };
-    }
-  },
-  /**
-   * Extracts the name component of the note title and capitlizes it
-   */
-  OnCreate: {
-    setTitle(props) {
-      const fName = props.currentNoteName;
-
-      if (fName.includes(".") && fName.lastIndexOf(".") < fName.length) {
-        const namepart = fName.substring(fName.lastIndexOf(".") + 1);
-        const capitilized = namepart.split('-').map(element => element[0].toUpperCase() + element.substring(1));
-
-        return capitilized.join(' ');
-      }
-      else {
-        return fName;
-      }
-    }
-  }
-}
-```
-
-### Create a new note with the Trait applied
-
-Run the command `Dendron: Create Note With Custom Trait`. Select your trait, `professional-connections`. This will bring up a lookup command with pre-filled contents in the input box for the note name. Click confirm. You should see a new note get generated, with the title modified automatically applied.
+![[Getting Started|dendron://dendron.dendron-site/dendron.topic.traits#getting-started]]


### PR DESCRIPTION
## What does this PR do?
Fixing some note trait documentation errors

## What issues does this PR fix or reference?
<!-- Delete section or leave empty if no related GitHub Issue exists -->

- Fixes:
OR
- Relates to:

> **NOTE:** `Fixes` will close the ticket after merging. `Relates to:` will leave the ticket open after merging.

### Merge requirements satisfied

> For more information, visit the [Contributing Guide for Documentation](https://wiki.dendron.so/notes/b58801fc-43a9-4d42-a58b-eabc3e8538cb/)

- [ ] Check rendered output to ensure formatting is correct for renderings of wikilinks, note refs, tables, and images. `Dendron: Show Preview` can be used in your workspace to confirm the page renders as expected. Sometimes, `Dendron: Reload Index` needs to be ran if certain wikilinks aren't working as expected. (ignore this if contribution is made via the `Edit this page on GitHub` button from the published site)
- [ ] If this PR includes any refactoring (renaming notes, renaming headers, etc.), make sure that these changes were done via [Dendron Refactoring Commands](https://wiki.dendron.so/notes/srajljj10V2dl19nCSFiC/). This will ensure that any other impacted areas of the documentation, that link to or embed modified notes (via note references), are automatically updated.

Verify GitHub Actions tests are passing, which can be seen in the `Checks` tab of the PR:

- [ ] `URL validator` GitHub Action passes
- [ ] `Dendron site build` GitHub Action passes

> **NOTE:** If you are a new contributor, a maintainer will need to provide approval for GitHub Actions to run on your PRs.
