### PR TITLE
Blank journal pages

### DIFF
--- a/vault/community.journal.md
+++ b/vault/community.journal.md
@@ -1,9 +1,0 @@
----
-id: l9C9X6OiXsnE1WGyCoXKc
-title: Journal
-desc: ''
-updated: 1640487420101
-created: 1640487420101
-stub: true
----
-

--- a/vault/community.journal.nut.2021.12.md
+++ b/vault/community.journal.nut.2021.12.md
@@ -1,9 +1,0 @@
----
-id: tWuWcaRnLAhcKhsISryrU
-title: '12'
-desc: ''
-updated: 1640487420101
-created: 1640487420101
-stub: true
----
-

--- a/vault/community.journal.nut.2021.md
+++ b/vault/community.journal.nut.2021.md
@@ -1,9 +1,0 @@
----
-id: 5PaTdBBH90H3zGjptToBs
-title: '2021'
-desc: ''
-updated: 1640487420101
-created: 1640487420101
-stub: true
----
-

--- a/vault/community.journal.nut.md
+++ b/vault/community.journal.nut.md
@@ -1,9 +1,0 @@
----
-id: 8U3ArSk25M2W5MUVEFReb
-title: Nut
-desc: ''
-updated: 1640487420101
-created: 1640487420101
-stub: true
----
-


### PR DESCRIPTION
## What does this PR do?
Looks like some blank journal pages have been accidently created.
I noticed they were blank on the website: https://wiki.dendron.so/notes/l9C9X6OiXsnE1WGyCoXKc/

## What issues does this PR fix or reference?
<!-- Delete section or leave empty if no related GitHub Issue exists -->

- Fixes: blank journal pages
OR
- Relates to:

> **NOTE:** `Fixes` will close the ticket after merging. `Relates to:` will leave the ticket open after merging.

### Merge requirements satisfied

> For more information, visit the [Contributing Guide for Documentation](https://wiki.dendron.so/notes/b58801fc-43a9-4d42-a58b-eabc3e8538cb/)

- [x] Check rendered output to ensure formatting is correct for renderings of wikilinks, note refs, tables, and images. `Dendron: Show Preview` can be used in your workspace to confirm the page renders as expected. Sometimes, `Dendron: Reload Index` needs to be ran if certain wikilinks aren't working as expected. (ignore this if contribution is made via the `Edit this page on GitHub` button from the published site)
- [x] If this PR includes any refactoring (renaming notes, renaming headers, etc.), make sure that these changes were done via [Dendron Refactoring Commands](https://wiki.dendron.so/notes/srajljj10V2dl19nCSFiC/). This will ensure that any other impacted areas of the documentation, that link to or embed modified notes (via note references), are automatically updated.

Verify GitHub Actions tests are passing, which can be seen in the `Checks` tab of the PR:

- [x] `URL validator` GitHub Action passes
- [x] `Dendron site build` GitHub Action passes

> **NOTE:** If you are a new contributor, a maintainer will need to provide approval for GitHub Actions to run on your PRs.
