### PR TITLE
docs: fix template variable documentation spelling

### DIFF
--- a/vault/dendron.topic.templates.template-variables.md
+++ b/vault/dendron.topic.templates.template-variables.md
@@ -10,7 +10,7 @@ created: 1653438949072
 
 {{fm.desc}}
 
-You can apply template variables by using the following syntax: `{{ VARAIBLE }}`
+You can apply template variables by using the following syntax: `{{ VARIABLE }}`
 
 ### Globally Available
 


### PR DESCRIPTION
## What does this PR do?

No functionality change, just a spelling error

### Merge requirements satisfied

> For more information, visit the [Contributing Guide for Documentation](https://wiki.dendron.so/notes/b58801fc-43a9-4d42-a58b-eabc3e8538cb/)

- [x] If this PR includes any refactoring (renaming notes, renaming headers, etc.), make sure that these changes were done via [Dendron Refactoring Commands](https://wiki.dendron.so/notes/srajljj10V2dl19nCSFiC/). This will ensure that any other impacted areas of the documentation, that link to or embed modified notes (via note references), are automatically updated.
- [x] Check rendered output to ensure formatting is correct for renderings of wikilinks, note refs, tables, and images. `Dendron: Show Preview` can be used in your workspace to confirm the page renders as expected. Sometimes, `Dendron: Reload Index` needs to be ran if certain wikilinks aren't working as expected. (ignore this if contribution is made via the `Edit this page on GitHub` button from the published site)

Verify GitHub Actions tests are passing, which can be seen in the `Checks` tab of the PR:

- [ ] `URL validator` GitHub Action passes
- [ ] `Dendron site build` GitHub Action passes

> **NOTE:** If you are a new contributor, a maintainer will need to provide approval for GitHub Actions to run on your PRs.
