### PR TITLE
chore: add manual migration instructions

### DIFF
--- a/vault/dendron.guides.troubleshooting.manual-migration.md
+++ b/vault/dendron.guides.troubleshooting.manual-migration.md
@@ -1,0 +1,33 @@
+---
+id: 4119x15gl9w90qx8qh1truj
+title: Manual Migration
+desc: ''
+updated: 1657008577615
+created: 1657008134225
+---
+
+You are upgrading from a version that is below 0.63.0, which we do not support direct automatic migration.
+You can either manually update the configuration or revert to a compatible older version before upgrading to the current version.
+
+If you have not set custom values for the deprecated configurations listed in [[Deprecated Configs|dendron://dendron.dendron-site/dendron.ref.config.vscode-config.deprecated]], you may safely ignore this warning.
+
+Otherwise, please follow the steps below:
+
+## Method 1: Reverting to a compatible version
+
+> This instruction reverts you to the last version of Dendron that supports automatic migration on upgrade.
+
+1. Go to the Extensions panel and find Dendron
+2. Click on the cog wheel icon and select `Install Another Version...`
+3. Select `0.100.0`, and wait for the installation to complete
+4. Reload VSCode and wait for Dendron to activate
+5. Update Dendron back to the latest version
+6. Confirm that configurations are migrated correctly
+
+## Method 2: Manual Migration
+
+> This instruction is for manually moving deprecated configurations to the correct location. If you've successfully migrated using the first method, you may skip this step.
+
+1. Open `dendron.code-workspace` and `dendron.yml`
+2. consult [[Deprecated Configs|dendron://dendron.dendron-site/dendron.ref.config.vscode-config.deprecated]] to find the deprecated configurations in `dendron.code-workspace` and move them to the correct location in `dendron.yml`
+3. Reload VSCode


### PR DESCRIPTION
## What does this PR do?
- This PR:
  - adds manual migration instructions that will be linked through a prompt that happens when a user upgrades Dendron from a legacy version

## What issues does this PR fix or reference?
<!-- Delete section or leave empty if no related GitHub Issue exists -->

- Fixes:
OR
- Relates to: dendronhq/dendron#3161

> **NOTE:** `Fixes` will close the ticket after merging. `Relates to:` will leave the ticket open after merging.

### Merge requirements satisfied

> For more information, visit the [Contributing Guide for Documentation](https://wiki.dendron.so/notes/b58801fc-43a9-4d42-a58b-eabc3e8538cb/)

- [ ] Check rendered output to ensure formatting is correct for renderings of wikilinks, note refs, tables, and images. `Dendron: Show Preview` can be used in your workspace to confirm the page renders as expected. Sometimes, `Dendron: Reload Index` needs to be ran if certain wikilinks aren't working as expected. (ignore this if contribution is made via the `Edit this page on GitHub` button from the published site)
- [ ] If this PR includes any refactoring (renaming notes, renaming headers, etc.), make sure that these changes were done via [Dendron Refactoring Commands](https://wiki.dendron.so/notes/srajljj10V2dl19nCSFiC/). This will ensure that any other impacted areas of the documentation, that link to or embed modified notes (via note references), are automatically updated.

Verify GitHub Actions tests are passing, which can be seen in the `Checks` tab of the PR:

- [ ] `URL validator` GitHub Action passes
- [ ] `Dendron site build` GitHub Action passes

> **NOTE:** If you are a new contributor, a maintainer will need to provide approval for GitHub Actions to run on your PRs.
