### PR TITLE
update doc for Go Next/Previous Sibling (pr 3184)

### DIFF
--- a/vault/dendron.topic.navigation.md
+++ b/vault/dendron.topic.navigation.md
@@ -2,7 +2,7 @@
 id: cphUwSPk12j4lS0tKjBdC
 title: Navigation
 desc: ''
-updated: 1651331181877
+updated: 1657145921970
 created: 1638899506405
 ---
 
@@ -67,6 +67,8 @@ Go to the next sibling
 
 Siblings with numeric names will be sorted numerically, whereas siblings with alphabetical names will be sorted alphabetically when determining the next sibling.
 
+When the active note is a journal note, the sibling navigation is in chronological order (`journal.dateFormat` of `dendron.yml` needs to be the default setting `y.MM.dd` to utilize chronological navigation)
+
 ![](https://foundation-prod-assetspublic53c57cce-8cpvgjldwysl.s3-us-west-2.amazonaws.com/assets/images/hierarchy.go-sibling.gif)
 
 ### Go Previous Sibling
@@ -78,6 +80,8 @@ Siblings with numeric names will be sorted numerically, whereas siblings with al
 Go to the previous sibling
 
 Siblings with numeric names will be sorted numerically, whereas siblings with alphabetical names will be sorted alphabetically when determining the previous sibling.
+
+When the active note is a journal note, the sibling navigation is in chronological order (`journal.dateFormat` of `dendron.yml` needs to be the default setting `y.MM.dd` to utilize chronological navigation)
 
 ![](https://foundation-prod-assetspublic53c57cce-8cpvgjldwysl.s3-us-west-2.amazonaws.com/assets/images/hierarchy.go-sibling.gif)
 

--- a/vault/dendron.topic.traits.md
+++ b/vault/dendron.topic.traits.md
@@ -1,16 +1,16 @@
 ---
 id: bdZhT3nF8Yz3WDzKp7hqh
-title: Traits
-desc: ''
-updated: 1656468624871
+title: Note Traits
+desc: 'Note traits let you customize the data of notes using code'
+updated: 1657121699475
 created: 1638842998292
 ---
 
 ## Summary
 
-Dendron's trait system allows you to create custom behavior and apply it to certain notes. An analogy for note traits is a typed system for programming languages.
+- _Note: This is a [[germ stage|dendron://dendron.dendron-site/tags.stage.germ]] feature that may have breaking changes in future versions of Dendron!_
 
-_Note: This is a [[germ stage|dendron://dendron.dendron-site/tags.stage.germ]] feature that may have breaking changes in future versions of Dendron!_
+{{fm.desc}}
 
 ## Use Cases
 - You want to have some of the characteristics of Dendron's built-in [[journal notes|dendron://dendron.dendron-site/dendron.topic.special-notes#journal-note]] or [[scratch notes|dendron://dendron.dendron-site/dendron.topic.special-notes#scratch-note]], but you want to customize the behavior yourself


### PR DESCRIPTION
## What does this PR do?
<!-- Describe pull request here. -->
Update doc for `Go Next Sibling` and `Go Previous Sibling`

PR: https://github.com/dendronhq/dendron/pull/3184

## What issues does this PR fix or reference?
<!-- Delete section or leave empty if no related GitHub Issue exists -->

- Fixes:
OR
- Relates to:

> **NOTE:** `Fixes` will close the ticket after merging. `Relates to:` will leave the ticket open after merging.

### Merge requirements satisfied

> For more information, visit the [Contributing Guide for Documentation](https://wiki.dendron.so/notes/b58801fc-43a9-4d42-a58b-eabc3e8538cb/)

- [x] Check rendered output to ensure formatting is correct for renderings of wikilinks, note refs, tables, and images. `Dendron: Show Preview` can be used in your workspace to confirm the page renders as expected. Sometimes, `Dendron: Reload Index` needs to be ran if certain wikilinks aren't working as expected. (ignore this if contribution is made via the `Edit this page on GitHub` button from the published site)
- [ ] If this PR includes any refactoring (renaming notes, renaming headers, etc.), make sure that these changes were done via [Dendron Refactoring Commands](https://wiki.dendron.so/notes/srajljj10V2dl19nCSFiC/). This will ensure that any other impacted areas of the documentation, that link to or embed modified notes (via note references), are automatically updated.

Verify GitHub Actions tests are passing, which can be seen in the `Checks` tab of the PR:

- [ ] `URL validator` GitHub Action passes
- [x] `Dendron site build` GitHub Action passes

> **NOTE:** If you are a new contributor, a maintainer will need to provide approval for GitHub Actions to run on your PRs.
