### PR TITLE
Minor grammar edit: "2" -> "two".

### DIFF
--- a/vault/dendron.topic.workspace.md
+++ b/vault/dendron.topic.workspace.md
@@ -96,7 +96,7 @@ Don't do any synchronization. This may be useful if you use some other tool to s
 
 ## Workspace Types
 
-Dendron recognizes 2 types of workspaces, Code and Native. When you initialize your workspace with
+Dendron recognizes two types of workspaces, Code and Native. When you initialize your workspace with
 the [[Initialize Workspace|dendron.ref.commands#initialize-workspace]] command, you get a Code
 workspace. Code workspaces include a `dendron.code-workspace` file which sets up vaults and
 recommends installing some useful extensions. Code workspaces are great when you are setting up a


### PR DESCRIPTION
Most style guides state that numbers below 10 should be written as words.

## What does this PR do?
It changes the use of "2" as a numeral into the word "two".

## What issues does this PR fix or reference?
<!-- Delete section or leave empty if no related GitHub Issue exists -->

- Fixes: A minor grammar issue.

> **NOTE:** `Fixes` will close the ticket after merging. `Relates to:` will leave the ticket open after merging.

### Merge requirements satisfied

> For more information, visit the [Contributing Guide for Documentation](https://wiki.dendron.so/notes/b58801fc-43a9-4d42-a58b-eabc3e8538cb/)

- [x ] Check rendered output to ensure formatting is correct for renderings of wikilinks, note refs, tables, and images. `Dendron: Show Preview` can be used in your workspace to confirm the page renders as expected. Sometimes, `Dendron: Reload Index` needs to be ran if certain wikilinks aren't working as expected. (ignore this if contribution is made via the `Edit this page on GitHub` button from the published site)
- [ ] If this PR includes any refactoring (renaming notes, renaming headers, etc.), make sure that these changes were done via [Dendron Refactoring Commands](https://wiki.dendron.so/notes/srajljj10V2dl19nCSFiC/). This will ensure that any other impacted areas of the documentation, that link to or embed modified notes (via note references), are automatically updated.

Verify GitHub Actions tests are passing, which can be seen in the `Checks` tab of the PR:

- [ ] `URL validator` GitHub Action passes
- [x] `Dendron site build` GitHub Action passes

> **NOTE:** If you are a new contributor, a maintainer will need to provide approval for GitHub Actions to run on your PRs.
