### PR TITLE
add doc for "Toggle Preview Lock" command

### DIFF
--- a/vault/dendron.topic.preview.commands.md
+++ b/vault/dendron.topic.preview.commands.md
@@ -2,9 +2,14 @@
 id: m05ghfkzdu4jzuec19lh7jl
 title: Commands
 desc: ''
-updated: 1657896450491
+updated: 1659515662710
 created: 1657896205318
 ---
 
-### Toggle Preview
+## Toggle Preview
+
 ![[dendron://dendron.dendron-site/dendron.topic.preview.commands.toggle-preview]]
+
+## Toggle Preview Lock
+
+![[dendron://dendron.dendron-site/dendron.topic.preview.commands.toggle-preview-lock]]

--- a/vault/dendron.topic.preview.commands.toggle-preview-lock.md
+++ b/vault/dendron.topic.preview.commands.toggle-preview-lock.md
@@ -1,0 +1,12 @@
+---
+id: h645aolt73djab3axh22gt8
+title: Toggle Preview Lock
+desc: |
+    Toggle lock state of the markdown preview
+updated: 1659515594705
+created: 1659515455838
+---
+
+## Summary
+
+{{fm.desc}}


### PR DESCRIPTION
## What does this PR do?
<!-- Describe pull request here. -->

add doc for "Toggle Preview Lock" command.
PR: +
- https://github.com/dendronhq/dendron/pull/3293
- https://github.com/dendronhq/dendron/pull/3327

## What issues does this PR fix or reference?
<!-- Delete section or leave empty if no related GitHub Issue exists -->

- Fixes:
OR
- Relates to:

> **NOTE:** `Fixes` will close the ticket after merging. `Relates to:` will leave the ticket open after merging.

### Merge requirements satisfied

> For more information, visit the [Contributing Guide for Documentation](https://wiki.dendron.so/notes/b58801fc-43a9-4d42-a58b-eabc3e8538cb/)

- [x] Check rendered output to ensure formatting is correct for renderings of wikilinks, note refs, tables, and images. `Dendron: Show Preview` can be used in your workspace to confirm the page renders as expected. Sometimes, `Dendron: Reload Index` needs to be ran if certain wikilinks aren't working as expected. (ignore this if contribution is made via the `Edit this page on GitHub` button from the published site)
- [ ] If this PR includes any refactoring (renaming notes, renaming headers, etc.), make sure that these changes were done via [Dendron Refactoring Commands](https://wiki.dendron.so/notes/srajljj10V2dl19nCSFiC/). This will ensure that any other impacted areas of the documentation, that link to or embed modified notes (via note references), are automatically updated.

Verify GitHub Actions tests are passing, which can be seen in the `Checks` tab of the PR:

- [ ] `URL validator` GitHub Action passes
- [ ] `Dendron site build` GitHub Action passes

> **NOTE:** If you are a new contributor, a maintainer will need to provide approval for GitHub Actions to run on your PRs.
