### PR TITLE
update documents for merge note

### DIFF
--- a/vault/dendron.topic.refactoring.commands.md
+++ b/vault/dendron.topic.refactoring.commands.md
@@ -2,7 +2,7 @@
 id: 45ecrq7l5z9l1vpwtr05q3h
 title: Commands
 desc: ''
-updated: 1655739692915
+updated: 1660042737685
 created: 1655109346797
 config:
   global:
@@ -16,6 +16,10 @@ config:
 ## Move Note
 
 ![[dendron.topic.refactoring.commands.move-note#summary,1:#*]]
+
+## Merge Note
+
+![[dendron.topic.refactoring.commands.merge-note#summary,1:#*]]
 
 ## Refactor Hierarchy
 

--- a/vault/dendron.topic.refactoring.commands.merge-note.md
+++ b/vault/dendron.topic.refactoring.commands.merge-note.md
@@ -1,0 +1,22 @@
+---
+id: nxarb351z0kfbl5mkw3arw6
+title: 'Dendron: Merge Note'
+desc: Merge a note into another note and update all backlinks
+updated: 1660043063628
+created: 1660042742775
+---
+
+> **{{fm.title}}** merges the _currently active note_ into another note of your choice. Please make sure the note you want to merge is the active note.
+
+> When prompted to select the destination, you cannot select the source note as the destination.
+
+## Summary
+
+{{fm.desc}}
+
+## Keybindings
+none
+
+## Details
+
+**{{fm.title}}** is a command that lets you merge the content of your active note into another note of your choice. Once the note is merged, all backlinks that the source note had will be updated so that it points to the merge destination, and the source note will be deleted.

--- a/vault/dendron.topic.refactoring.commands.merge-note.md
+++ b/vault/dendron.topic.refactoring.commands.merge-note.md
@@ -2,7 +2,7 @@
 id: nxarb351z0kfbl5mkw3arw6
 title: 'Dendron: Merge Note'
 desc: Merge a note into another note and update all backlinks
-updated: 1660043063628
+updated: 1660100186850
 created: 1660042742775
 ---
 
@@ -19,4 +19,6 @@ none
 
 ## Details
 
-**{{fm.title}}** is a command that lets you merge the content of your active note into another note of your choice. Once the note is merged, all backlinks that the source note had will be updated so that it points to the merge destination, and the source note will be deleted.
+**{{fm.title}}** is a command that lets you merge the content of your active note into another note of your choice.
+When merged, the entire body of the source note is appended to the end of the destination note.
+Also, all backlinks that the source note had will be updated so that it points to the merge destination, and finally the source note will be deleted.

--- a/vault/dendron.topic.refactoring.md
+++ b/vault/dendron.topic.refactoring.md
@@ -2,7 +2,7 @@
 id: srajljj10V2dl19nCSFiC
 title: Refactoring
 desc: ""
-updated: 1657867234229
+updated: 1660043244156
 created: 1638900089932
 ---
 
@@ -79,6 +79,17 @@ Features that help update the structure of Dendron.
 5. Select note(s) you want to move to the new vault and hit enter. Clicking the square icon in the lookup bar will enable multi-select.
 6. You will be prompted to select the vault you want to move the selected note(s) to.
 7. Notice the notes have been moved to the selected vault and links to those notes have also been updated.
+
+#### Merge one note with another note
+
+> See [[dendron.topic.refactoring.commands.merge-note]] for more information
+
+1. Create notes called `source`, `dest`, with any content, and `ref` with wikilinks that point to `source`.
+2. Open the note `source`.
+3. Run [[dendron.topic.refactoring.commands.merge-note]] in the command palette
+4. When prompted for the destination, select `dest`.
+5. Notice that the note `source` is deleted, and the content of `source` is appended at the end of note `dest`.
+6. Also note that the wikilinks in `ref` that used to point to `source` is now updated to point to the note `dest`.
 
 ### Refactoring an entire hierarchy
 


### PR DESCRIPTION
## What does this PR do?
- Add documents for the new command `Dendron: Merge Note`

## What issues does this PR fix or reference?
<!-- Delete section or leave empty if no related GitHub Issue exists -->

- Relates to: dendronhq/dendron#3349

> **NOTE:** `Fixes` will close the ticket after merging. `Relates to:` will leave the ticket open after merging.

### Merge requirements satisfied

> For more information, visit the [Contributing Guide for Documentation](https://wiki.dendron.so/notes/b58801fc-43a9-4d42-a58b-eabc3e8538cb/)

- [ ] Check rendered output to ensure formatting is correct for renderings of wikilinks, note refs, tables, and images. `Dendron: Show Preview` can be used in your workspace to confirm the page renders as expected. Sometimes, `Dendron: Reload Index` needs to be ran if certain wikilinks aren't working as expected. (ignore this if contribution is made via the `Edit this page on GitHub` button from the published site)
- [ ] If this PR includes any refactoring (renaming notes, renaming headers, etc.), make sure that these changes were done via [Dendron Refactoring Commands](https://wiki.dendron.so/notes/srajljj10V2dl19nCSFiC/). This will ensure that any other impacted areas of the documentation, that link to or embed modified notes (via note references), are automatically updated.

Verify GitHub Actions tests are passing, which can be seen in the `Checks` tab of the PR:

- [ ] `URL validator` GitHub Action passes
- [ ] `Dendron site build` GitHub Action passes

> **NOTE:** If you are a new contributor, a maintainer will need to provide approval for GitHub Actions to run on your PRs.
