### PR TITLE
add new note traits onCreate method

### DIFF
--- a/vault/dendron.topic.traits.api.md
+++ b/vault/dendron.topic.traits.api.md
@@ -1,8 +1,8 @@
 ---
 id: oOIEFJc6DTgS71mmh89WQ
 title: API
-desc: 'This contains API documentation for trait behavior'
-updated: 1659714599999
+desc: "This contains API documentation for trait behavior"
+updated: 1661455328472
 created: 1638844803983
 tags: [stage.germ]
 ---
@@ -24,9 +24,11 @@ This contains properties that are functions that will run as a note is being cre
 See [[Creation Properties|dendron://dendron.dendron-site/dendron.topic.traits.api#creation-properties]]
 
 #### Return
+
 A JSON Object with the following properties:
-- name: a string with the name of the note which is about to be created
-- promptUserForModfication: a boolean value. If true, before the note is created, then a lookup control will appear, allowing the user to further modify the note name. The lookup will be pre-filled with the contents of the `name` property. If false, then no lookup control will appear and the note will be created with the name set by the `name` property.
+
+-   name: a string with the name of the note which is about to be created
+-   promptUserForModfication: a boolean value. If true, before the note is created, then a lookup control will appear, allowing the user to further modify the note name. The lookup will be pre-filled with the contents of the `name` property. If false, then no lookup control will appear and the note will be created with the name set by the `name` property.
 
 > ❗️ Note: Dendron may further format the note name to make sure it is compatible. Spaces will be replaced with `-` and the note name will be converted to lower case.
 
@@ -54,9 +56,10 @@ _None_
 
 #### Return
 
-The name of the note to use as the template. You can use a [[xvault link|dendron.topic.links#cross-vault-links]] to specify the vault in a multi-vault setting, otherwise, this will use the same vault as the current open note. 
+The name of the note to use as the template. You can use a [[xvault link|dendron.topic.links#cross-vault-links]] to specify the vault in a multi-vault setting, otherwise, this will use the same vault as the current open note.
 
 Example:
+
 ```js
   OnCreate: {
 		...
@@ -66,11 +69,19 @@ Example:
   },
 ```
 
+### setVault
+
+Specify the vault in which a new note is created.
+
+#### Return
+
+The name of the vault in which to create a new note.
+
 ## Creation Properties
 
-- currentNoteName - for `setNameModifier()`, this contains the name of the Dendron note that is currently in focus in the editor. If no note is in focus, then this returns `undefined`.  For `setTitle()`, this contains the note name returned from `setNoteModifier()`.
-- selectedText - contains the text that has been highlighted in the current editor of a Dendron Note. If no text is highlighted, or if the highlighted text is not in a Dendron note, this returns `undefined`.
-- clipboard - contains any text currently on the clipboard, or `undefined` if there is no text.
+-   currentNoteName - for `setNameModifier()`, this contains the name of the Dendron note that is currently in focus in the editor. If no note is in focus, then this returns `undefined`. For `setTitle()`, this contains the note name returned from `setNoteModifier()`.
+-   selectedText - contains the text that has been highlighted in the current editor of a Dendron Note. If no text is highlighted, or if the highlighted text is not in a Dendron note, this returns `undefined`.
+-   clipboard - contains any text currently on the clipboard, or `undefined` if there is no text.
 
 ## Included Modules
 


### PR DESCRIPTION
## What does this PR do?
<!-- Describe pull request here. -->

Add explanation for a new api (method) for `onCreate` method of note traits.

## What issues does this PR fix or reference?
<!-- Delete section or leave empty if no related GitHub Issue exists -->

task: `[[Specify Vault for Note Trait|task.2022.08.23.specify-vault-for-note-trait]]`

- Fixes:
OR
- Relates to:

> **NOTE:** `Fixes` will close the ticket after merging. `Relates to:` will leave the ticket open after merging.

### Merge requirements satisfied

> For more information, visit the [Contributing Guide for Documentation](https://wiki.dendron.so/notes/b58801fc-43a9-4d42-a58b-eabc3e8538cb/)

- [x] Check rendered output to ensure formatting is correct for renderings of wikilinks, note refs, tables, and images. `Dendron: Show Preview` can be used in your workspace to confirm the page renders as expected. Sometimes, `Dendron: Reload Index` needs to be ran if certain wikilinks aren't working as expected. (ignore this if contribution is made via the `Edit this page on GitHub` button from the published site)
- [x] If this PR includes any refactoring (renaming notes, renaming headers, etc.), make sure that these changes were done via [Dendron Refactoring Commands](https://wiki.dendron.so/notes/srajljj10V2dl19nCSFiC/). This will ensure that any other impacted areas of the documentation, that link to or embed modified notes (via note references), are automatically updated.

Verify GitHub Actions tests are passing, which can be seen in the `Checks` tab of the PR:

- [x] `URL validator` GitHub Action passes
- [x] `Dendron site build` GitHub Action passes

> **NOTE:** If you are a new contributor, a maintainer will need to provide approval for GitHub Actions to run on your PRs.
