### PR TITLE
Add instructions for moving multiple notes

### DIFF
--- a/vault/dendron.topic.refactoring.commands.move-note.md
+++ b/vault/dendron.topic.refactoring.commands.move-note.md
@@ -2,7 +2,7 @@
 id: 98ywiw4211q9sx0v98lbo88
 title: 'Dendron: Move Note'
 desc: Move a note to another vault and update all backlinks to that note.
-updated: 1655739264942
+updated: 1661758420010
 created: 1655129267874
 ---
 
@@ -18,7 +18,15 @@ none
 
 ## Details
 
-**{{fm.title}}** is a command that lets you move a note between vaults when in a [[Multi-vault|dendron://dendron.dendron-site/dendron.topic.multi-vault]] workspace, and will also update all references in other notes of that note.
+**{{fm.title}}** is a command that lets you move a note between vaults when in a [[Multi-vault|dendron://dendron.dendron-site/dendron.topic.multi-vault]] workspace, and will also update all references in other notes of that note. This command can move several notes at once, too (i.e. a note and all their children)
 
-## Moving a note using the file explorer
+1. Call **{{fm.title}}** from the command bar.
+2. Type the note's title.
+   1. (Optional, for moving multiple notes) Type the parent's note and click on the square icon on the right of the panel (see image below).
+3. Select the new vault where you want to move the note(s) to.
+
+![**{{fm.title}}**: Selecting several notes at once](https://org-dendron-public-assets.s3.amazonaws.com/images/move-multiple-notes.png))
+
+
+### Moving a note using the file explorer
 You can also select **{{fm.title}}** after right clicking on a note in the explorer to move that note. This will also update the backlinks as well.


### PR DESCRIPTION
## What does this PR do?
Adds instructions on how to move multiple notes at once.


### Merge requirements satisfied

> For more information, visit the [Contributing Guide for Documentation](https://wiki.dendron.so/notes/b58801fc-43a9-4d42-a58b-eabc3e8538cb/)

- [x] Check rendered output to ensure formatting is correct for renderings of wikilinks, note refs, tables, and images. `Dendron: Show Preview` can be used in your workspace to confirm the page renders as expected. Sometimes, `Dendron: Reload Index` needs to be ran if certain wikilinks aren't working as expected. (ignore this if contribution is made via the `Edit this page on GitHub` button from the published site)

Verify GitHub Actions tests are passing, which can be seen in the `Checks` tab of the PR:

- [ ] `URL validator` GitHub Action passes
- [x] `Dendron site build` GitHub Action passes

> **NOTE:** If you are a new contributor, a maintainer will need to provide approval for GitHub Actions to run on your PRs.
