### PR TITLE
Add video embed link for 2022-08-29 greenhouse talk

### DIFF
--- a/vault/community.events.greenhouse.2022-07-29-modularizing-documentation.md
+++ b/vault/community.events.greenhouse.2022-07-29-modularizing-documentation.md
@@ -3,7 +3,7 @@ id: k5zg3zk1ffmsrmojnvn8uxw
 title: >-
     Seeding Digital Gardens and Connecting Second Brains
 desc: 'Greenhouse Talk on modularizing public documentation, ebooks, and other web content for Dendron consumption.'
-updated: 1659284818559
+updated: 1661824704713
 created: 1659284597998
 ---
 
@@ -13,7 +13,7 @@ created: 1659284597998
 
 ## Video
 
-<iframe width="1280" height="720" src="https://www.youtube.com/embed/IQusAQGxTyg" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe width="640" height="360" src="https://www.youtube.com/embed/IQusAQGxTyg" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 ## Details
 

--- a/vault/community.events.greenhouse.2022-08-26-markdown-language-server-and-progressive-summarization.md
+++ b/vault/community.events.greenhouse.2022-08-26-markdown-language-server-and-progressive-summarization.md
@@ -2,11 +2,18 @@
 id: slklff1t4qs9od0l0dwvkx4
 title: >-
     August Greenhouse: Markdown Language Server and Progressive Summarization for Developers
-desc: ''
-updated: 1661267650910
+desc: 'Two Greenhouse talks, one on the new VS Code markdown language server and the other on adapting the method of progressive summarization for developers.'
+updated: 1661825253229
 created: 1661226904533
 ---
 
+## Summary
+
+{{fm.desc}}
+
+## Video
+
+<iframe width="640" height="360" src="https://www.youtube.com/embed/EPGDTl3sbc4" title="Greenhouse August 2022 - The VS Code Markdown Language Server + Progressive Summarization for Devs" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 ## Talks
 
@@ -18,6 +25,9 @@ What's next for Markdown tooling? That's what we're exploring with the new Markd
 
 In this talk, I'll discuss why we decided to build a language server for Markdown and how you can get involved. Together we can help push Markdown tooling forward for everyone!
 
+References:
+- A blog post Matt mentioned in the talk: <https://code.visualstudio.com/blogs/2022/08/16/markdown-language-server>
+
 ### Progressive Summarization for Developers
 
 > Speaker: [Kevin Lin](https://twitter.com/kevins8), Founder of Dendron
@@ -28,10 +38,3 @@ Documentation for  software is both extensive and fluid. The details and corner 
 This is why we tend to not bother - but this results in a perpetual groundhogs day of stack overflow answers and google queries.
 
 In this talk, I will talk about a workflow I've developed to incrementally build up a knowledge base that encompasses all the software I have ever used and how I use it in my day to day.
-
-## Video
-
-Talk scheduled for August 26th at 9 AM PST. 
-See [luma](https://lu.ma/knu8uopf) page for more details.
-
-


### PR DESCRIPTION
Also changed the size of the video embed on the entry for the preceding
greenhouse talk to fit better on the page.