### PR TITLE
add docs for giscus

### DIFF
--- a/vault/dendron.ref.config.publishing.md
+++ b/vault/dendron.ref.config.publishing.md
@@ -2,7 +2,7 @@
 id: q960Z622o0RLO32w0B8SP
 title: Publishing
 desc: ''
-updated: 1653581676999
+updated: 1662436304428
 created: 1644903086084
 config:
   global:
@@ -91,6 +91,9 @@ config:
 
 ## github
 ![[github|dendron.topic.publish.config.github]]
+
+## giscus
+![[giscus|dendron.topic.publish.config.giscus]]
 
 # Note 
 

--- a/vault/dendron.topic.frontmatter.config.publishing.enableGiscus.md
+++ b/vault/dendron.topic.frontmatter.config.publishing.enableGiscus.md
@@ -1,0 +1,39 @@
+---
+id: kgnufytpadq0512gboskao2
+title: enableGiscus
+desc: 'Enable Giscus discussion widget in this page?'
+updated: 1662440983905
+created: 1662440616045
+---
+
+## Summary
+
+- type: `boolean`
+- default: `false`
+- required: `false`
+
+## Description
+{{fm.desc}}
+
+[Giscus.app](https://giscus.app) is a comment system that is powered by Github Discussions.
+
+You can add a comment thread at the bottom of each page by setting `enableGiscus` in the note's frontmatter.
+
+In order for this to have effect, you need to have the [[giscus|dendron.topic.publish.config.giscus]] configurations properly set up.
+
+Please use the [configuration tool](https://giscus.app) that Giscus provides to populate the configurations.
+
+## Example
+
+```
+---
+id: 123
+title: "Some note"
+desc: "A note with Giscus enabled"
+updated: 1234567890
+created: 1234567890
+enableGiscus: true
+---
+
+...
+```

--- a/vault/dendron.topic.publish.config.giscus.category.md
+++ b/vault/dendron.topic.publish.config.giscus.category.md
@@ -1,0 +1,23 @@
+---
+id: ir55dh1fubfwy7xsi0idzvs
+title: Category
+desc: 'Category where the discussion will be searched'
+updated: 1662438677077
+created: 1662438372429
+---
+
+- type: `string`
+- default: N/A
+- required: `false`
+
+## Description
+
+{{fm.desc}}
+
+## Example
+
+```yml
+  publishing:
+    giscus:
+      category: "Announcements"
+```

--- a/vault/dendron.topic.publish.config.giscus.categoryId.md
+++ b/vault/dendron.topic.publish.config.giscus.categoryId.md
@@ -1,0 +1,27 @@
+---
+id: 0qvgnwf7ox5skwv7e95b3w3
+title: categoryId
+desc: 'ID of the category where the discussion will be searched'
+updated: 1662438880607
+created: 1662438690584
+---
+
+> Please use the [configuration tool](https://giscus.app) to figure out your category ID.  
+> When you select your public repository from the tool, you will be given a dropdown of available Github Discussions categories in your repository.  
+> When you select the category from the dropdown, the category ID will be automatically be generated.
+
+- type: `string`
+- default: N/A
+- required: `false`
+
+## Description
+
+{{fm.desc}}.
+
+## Example
+
+```yml
+  publishing:
+    giscus:
+      categoryId: "1234567890"
+```

--- a/vault/dendron.topic.publish.config.giscus.emitMetadata.md
+++ b/vault/dendron.topic.publish.config.giscus.emitMetadata.md
@@ -1,0 +1,23 @@
+---
+id: hafabt5lpk0kwbzeqy74ecz
+title: emitMetadata
+desc: 'Emit the discussion metadata periodically to the parent page'
+updated: 1662440117517
+created: 1662440050719
+---
+
+- type: `0` | `1`
+- default: N/A
+- required: `false`
+
+## Description
+
+{{fm.desc}}.
+
+## Example
+
+```yml
+  publishing:
+    giscus:
+      emitMetadata: "0"
+```

--- a/vault/dendron.topic.publish.config.giscus.host.md
+++ b/vault/dendron.topic.publish.config.giscus.host.md
@@ -1,0 +1,26 @@
+---
+id: 8x5qwdsh05n4wry9tdhedl1
+title: Host
+desc: 'Host of the Giscus server'
+updated: 1662437870371
+created: 1662437382842
+---
+
+> This is only required if you wish to [self-host](https://github.com/giscus/giscus/blob/main/SELF-HOSTING.md) Giscus.  
+> Remove this configuration from `dendron.yml` if you are not self hosting.
+
+- type: `string`
+- default: N/A
+- required: `false`
+
+## Description
+
+{{fm.desc}}.
+
+## Example
+
+```yml
+  publishing:
+    giscus:
+      host: my-custom-host.com
+```

--- a/vault/dendron.topic.publish.config.giscus.id.md
+++ b/vault/dendron.topic.publish.config.giscus.id.md
@@ -1,0 +1,23 @@
+---
+id: 6qmzt673xptyco6lf98qpx6
+title: Id
+desc: 'Set the id of the Giscus component'
+updated: 1662437419645
+created: 1662436933073
+---
+
+- type: `string`
+- default: N/A
+- required: `false`
+
+## Description
+
+{{fm.desc}}.
+
+## Example
+
+```yml
+  publishing:
+    giscus:
+      id: comments
+```

--- a/vault/dendron.topic.publish.config.giscus.inputPosition.md
+++ b/vault/dendron.topic.publish.config.giscus.inputPosition.md
@@ -1,0 +1,23 @@
+---
+id: tyyypxu9xzesgu82t4884t7
+title: inputPosition
+desc: 'Placement of the comment box'
+updated: 1662440171341
+created: 1662440123552
+---
+
+- type: `top` | `bottom`
+- default: N/A
+- required: `true`
+
+## Description
+
+{{fm.desc}}.
+
+## Example
+
+```yml
+  publishing:
+    giscus:
+      inputPosition: "top"
+```

--- a/vault/dendron.topic.publish.config.giscus.lang.md
+++ b/vault/dendron.topic.publish.config.giscus.lang.md
@@ -1,0 +1,41 @@
+---
+id: eih9eyvx0y2kp6eua04zmvk
+title: Lang
+desc: 'Language that Giscus will be displayed in'
+updated: 1662440332804
+created: 1662440178085
+---
+
+- type: 
+  | `de`
+  | `gsw`
+  | `en`
+  | `es`
+  | `fr`
+  | `id`
+  | `it`
+  | `ja`
+  | `ko`
+  | `nl`
+  | `pl`
+  | `pt`
+  | `ro`
+  | `ru`
+  | `tr`
+  | `vi`
+  | `zh-CN`
+  | `zh-TW`
+- default: N/A
+- required: `false`
+
+## Description
+
+{{fm.desc}}.
+
+## Example
+
+```yml
+  publishing:
+    giscus:
+      lang: "en"
+```

--- a/vault/dendron.topic.publish.config.giscus.loading.md
+++ b/vault/dendron.topic.publish.config.giscus.loading.md
@@ -1,0 +1,23 @@
+---
+id: 6nw224xdro5hh50t5oo211i
+title: Loading
+desc: 'Whether the iframe should be loaded lazily or eagerly'
+updated: 1662440318123
+created: 1662440262441
+---
+
+- type: `lazy` | `eager`
+- default: N/A
+- required: `false`
+
+## Description
+
+{{fm.desc}}.
+
+## Example
+
+```yml
+  publishing:
+    giscus:
+      loading: "lazy"
+```

--- a/vault/dendron.topic.publish.config.giscus.mapping.md
+++ b/vault/dendron.topic.publish.config.giscus.mapping.md
@@ -1,0 +1,23 @@
+---
+id: xu0sd04shixsz6wdns8hiff
+title: Mapping
+desc: 'Set the mapping between the parent page and the discussion'
+updated: 1662439498810
+created: 1662439088980
+---
+
+- type: `url` | `title` | `og:title` | `specific` | `number` | `pathname`
+- default: N/A
+- required: `true`
+
+## Description
+
+{{fm.desc}}.
+
+## Example
+
+```yml
+  publishing:
+    giscus:
+      mapping: "pathname"
+```

--- a/vault/dendron.topic.publish.config.giscus.md
+++ b/vault/dendron.topic.publish.config.giscus.md
@@ -1,0 +1,112 @@
+---
+id: dgxeztu4fojuo9ulcwlzocu
+title: giscus
+desc: 'Configuration namepsace that holds all Giscus related publishing settings.'
+updated: 1662441645837
+created: 1662436288691
+config:
+  global:
+    enableChildLinks: false
+---
+
+> All required fields in this configuration namespace can be generated through the [configuration tool](https://giscus.app)  
+
+> To learn more about Giscus, please refer to [[dendron.topic.publish.giscus]]
+
+## Summary
+{{fm.desc}}
+
+Below is an overview of what the {{fm.title}} namespace looks like:
+```yml
+publishing:
+  giscus:
+    id:
+    host:
+    repo:
+    repoId:
+    category:
+    categoryId:
+    mapping:
+    term:
+    theme:
+    strict:
+    reactionsEnabled:
+    emitMetadata:
+    inputPosition:
+    lang:
+    loading:
+```
+
+***
+## id
+![[id|dendron.topic.publish.config.giscus.id]]
+
+***
+
+## host
+![[host|dendron.topic.publish.config.giscus.host]]
+
+***
+
+## repo
+![[repo|dendron.topic.publish.config.giscus.repo]]
+
+***
+
+## repoId
+![[repoId|dendron.topic.publish.config.giscus.repoId]]
+
+***
+
+## category
+![[category|dendron.topic.publish.config.giscus.category]]
+
+***
+
+## categoryId
+![[categoryId|dendron.topic.publish.config.giscus.categoryId]]
+
+***
+
+## mapping
+![[mapping|dendron.topic.publish.config.giscus.mapping]]
+
+***
+
+## term
+![[term|dendron.topic.publish.config.giscus.term]]
+
+***
+
+## theme
+![[theme|dendron.topic.publish.config.giscus.theme]]
+
+***
+
+## strict
+![[strict|dendron.topic.publish.config.giscus.strict]]
+
+***
+
+## reactionsEnabled
+![[reactionsEnabled|dendron.topic.publish.config.giscus.reactionsEnabled]]
+
+***
+
+## emitMetadata
+![[emitMetadata|dendron.topic.publish.config.giscus.emitMetadata]]
+
+***
+
+## inputPosition
+![[inputPosition|dendron.topic.publish.config.giscus.inputPosition]]
+
+***
+
+## lang
+![[lang|dendron.topic.publish.config.giscus.lang]]
+
+***
+
+## loading
+![[loading|dendron.topic.publish.config.giscus.loading]]

--- a/vault/dendron.topic.publish.config.giscus.reactionsEnabled.md
+++ b/vault/dendron.topic.publish.config.giscus.reactionsEnabled.md
@@ -1,0 +1,23 @@
+---
+id: bsc5eitizg50wikfa79pdqm
+title: reactionsEnabled
+desc: 'Enable reactions to the main post of the discussion'
+updated: 1662440024905
+created: 1662439969500
+---
+
+- type: `0` | `1`
+- default: N/A
+- required: `false`
+
+## Description
+
+{{fm.desc}}.
+
+## Example
+
+```yml
+  publishing:
+    giscus:
+      reactionsEnabled: "1"
+```

--- a/vault/dendron.topic.publish.config.giscus.repo.md
+++ b/vault/dendron.topic.publish.config.giscus.repo.md
@@ -1,0 +1,27 @@
+---
+id: o0pdj7oeam8lz7uwh4jzwxn
+title: Repo
+desc: 'Repository where the discussion is stored.'
+updated: 1662438094967
+created: 1662437880425
+---
+
+> The string should be formatted in the following form:  
+> `{user name}/{repo name}` for personal repositories
+> `{organization name}/{repo name}` for organization repositories
+
+- type: `${string}/${string}`
+- default: N/A
+- required: `true`
+
+## Descroption
+
+{{fm.desc}}.
+
+## Example
+
+```yml
+  publishing:
+    giscus:
+      repo: "dendronhq/dendron-site"
+```

--- a/vault/dendron.topic.publish.config.giscus.repoId.md
+++ b/vault/dendron.topic.publish.config.giscus.repoId.md
@@ -1,0 +1,25 @@
+---
+id: 70m7iwf643w0m2rc22ddcez
+title: repoId
+desc: 'ID of the repository where the discussion is stored'
+updated: 1662438361392
+created: 1662438226408
+---
+
+> Please use the [configuration tool](https://giscus.app) to figure out your repository ID.  
+> When you select your public repository from the tool, the ID will be automatically generated.
+
+- type: `string`
+- default: N/A
+- required: `true`
+
+## Description
+
+{{fm.desc}}
+
+## Example
+```yml
+  publishing:
+    giscus:
+      repoId: "1234567890"
+```

--- a/vault/dendron.topic.publish.config.giscus.strict.md
+++ b/vault/dendron.topic.publish.config.giscus.strict.md
@@ -1,0 +1,23 @@
+---
+id: 0iwki7d5617facmxno3oaad
+title: Strict
+desc: 'Use strict title matching'
+updated: 1662440045136
+created: 1662439905583
+---
+
+- type: `0` | `1`
+- default: N/A
+- required: `false`
+
+## Description
+
+{{fm.desc}}.
+
+## Example
+
+```yml
+  publishing:
+    giscus:
+      strict: "0"
+```

--- a/vault/dendron.topic.publish.config.giscus.term.md
+++ b/vault/dendron.topic.publish.config.giscus.term.md
@@ -1,0 +1,25 @@
+---
+id: kgddzrzybqg8dbacq7b2d1o
+title: Term
+desc: 'Search term to use when searching for the discussion'
+updated: 1662439722443
+created: 1662439583004
+---
+
+> ⚠️ Due to limitations, this configuration currently has no effect when publishing your notes with Dendron.
+
+- type: `string`
+- default: N/A
+- required: `false`
+
+## Description
+
+{{fm.desc}}
+
+## Example
+
+```yml
+  publishing:
+    giscus:
+      term: "term"
+```

--- a/vault/dendron.topic.publish.config.giscus.theme.md
+++ b/vault/dendron.topic.publish.config.giscus.theme.md
@@ -1,0 +1,37 @@
+---
+id: zihyua4xcv7ypqtlqwyx8v1
+title: Theme
+desc: 'Theme that Giscus will be displayed in'
+updated: 1662439897417
+created: 1662439727887
+---
+
+> ⚠️ Due to limitations, experimental custom theme support is limited when publishing your notes with Dendron.  
+> Only the provided themes are supported.
+
+- type: 
+  | `light`
+  | `light_high_contrast`
+  | `light_protanopia`
+  | `light_tritanopia`
+  | `dark`
+  | `dark_high_contrast`
+  | `dark_protanopia`
+  | `dark_tritanopia`
+  | `dark_dimmed`
+  | `transparent_dark`
+  | `preferred_color_scheme`
+- default: N/A
+- required: false
+
+## Description
+
+{{fm.desc}}.
+
+## Example
+
+```yml
+  publishing:
+    giscus:
+      theme: preferred_color_scheme
+```

--- a/vault/dendron.topic.publish.config.md
+++ b/vault/dendron.topic.publish.config.md
@@ -2,7 +2,7 @@
 id: fabYbPyk3DMCMoG92lIrq
 title: Configuration
 desc: 'Configuration namespace that holds all Dendron Publishing related settings.'
-updated: 1661977742537
+updated: 1662440551621
 created: 1637772506823
 config:
   global:
@@ -54,6 +54,22 @@ publishing:
     editBranch:
     editViewMode:
     editRepository:
+  giscus:
+    id:
+    host:
+    repo:
+    repoId:
+    category:
+    categoryId:
+    mapping:
+    term:
+    theme:
+    strict:
+    reactionsEnabled:
+    emitMetadata:
+    inputPosition:
+    lang:
+    loading:
 ```
 
 > Please note that the properties listed below are not strictly categorized by namespace, but by what they do. Use the namespace described in the summary section of this note to reference the actual organization of these properties.
@@ -119,6 +135,26 @@ These are properties related to GitHub.
   - [[editViewMode|dendron.topic.publish.config.github.editViewMode]]
   - [[editBranch|dendron.topic.publish.config.github.editBranch]]
   - [[editRepository|dendron.topic.publish.config.github.editRepository]]
+
+## Giscus properties
+These are properties related to Giscus widgets.
+
+- [[giscus|dendron.topic.publish.config.giscus]]
+  - [[category|dendron://dendron.dendron-site/dendron.topic.publish.config.giscus.category]]
+  - [[host|dendron://dendron.dendron-site/dendron.topic.publish.config.giscus.host]]
+  - [[id|dendron://dendron.dendron-site/dendron.topic.publish.config.giscus.id]]
+  - [[lang|dendron://dendron.dendron-site/dendron.topic.publish.config.giscus.lang]]
+  - [[loading|dendron://dendron.dendron-site/dendron.topic.publish.config.giscus.loading]]
+  - [[mapping|dendron://dendron.dendron-site/dendron.topic.publish.config.giscus.mapping]]
+  - [[repo|dendron://dendron.dendron-site/dendron.topic.publish.config.giscus.repo]]
+  - [[strict|dendron://dendron.dendron-site/dendron.topic.publish.config.giscus.strict]]
+  - [[term|dendron://dendron.dendron-site/dendron.topic.publish.config.giscus.term]]
+  - [[theme|dendron://dendron.dendron-site/dendron.topic.publish.config.giscus.theme]]
+  - [[categoryId|dendron://dendron.dendron-site/dendron.topic.publish.config.giscus.categoryId]]
+  - [[emitMetadata|dendron://dendron.dendron-site/dendron.topic.publish.config.giscus.emitMetadata]]
+  - [[inputPosition|dendron://dendron.dendron-site/dendron.topic.publish.config.giscus.inputPosition]]
+  - [[reactionsEnabled|dendron://dendron.dendron-site/dendron.topic.publish.config.giscus.reactionsEnabled]]
+  - [[repoId|dendron://dendron.dendron-site/dendron.topic.publish.config.giscus.repoId]]
 
 ## Advanced Properties
 

--- a/vault/dendron.topic.publish.giscus.md
+++ b/vault/dendron.topic.publish.giscus.md
@@ -1,0 +1,25 @@
+---
+id: aepo60t1efg7w76ik9evokq
+title: Giscus
+desc: ''
+updated: 1662441587888
+created: 1662440909642
+---
+
+> Currently Giscus is only available for public repositories hosted on GitHub.
+
+## Summary
+[Giscus](https://giscus.app) is a commenting system powered by [GitHub Discissions](https://docs.github.com/en/discussions).
+
+## Details
+
+Since Dendron utilizes Git for syncing workspaces, if you use GitHub to host your public notes, you can use the Discussion tab as a backend for comments in your published notes.
+
+This feature can be enabled on a per-note basis, so you can enable comments only on the notes you wish to collect feedback.
+
+### Getting started
+
+1. Use the [Configuration tool](https://giscus.app) to generate the giscus configurations needed for the public repository.
+2. Use the generated values to update the [[giscus|dendron.topic.publish.config.giscus]] configuration namespace in `dendron.yml`.
+3. For each note that you want the Giscus widget to appear, add the frontmatter key [[dendron.topic.frontmatter.config.publishing.enableGiscus]].
+4. Publish your notes and test if they work as intended.


### PR DESCRIPTION
## What does this PR do?
<!-- Describe pull request here. -->
- Add notes for the new Giscus integration

## What issues does this PR fix or reference?
<!-- Delete section or leave empty if no related GitHub Issue exists -->

- Fixes:
OR
- Relates to: dendronhq/dendron#3469

> **NOTE:** `Fixes` will close the ticket after merging. `Relates to:` will leave the ticket open after merging.

### Merge requirements satisfied

> For more information, visit the [Contributing Guide for Documentation](https://wiki.dendron.so/notes/b58801fc-43a9-4d42-a58b-eabc3e8538cb/)

- [ ] Check rendered output to ensure formatting is correct for renderings of wikilinks, note refs, tables, and images. `Dendron: Show Preview` can be used in your workspace to confirm the page renders as expected. Sometimes, `Dendron: Reload Index` needs to be ran if certain wikilinks aren't working as expected. (ignore this if contribution is made via the `Edit this page on GitHub` button from the published site)
- [ ] If this PR includes any refactoring (renaming notes, renaming headers, etc.), make sure that these changes were done via [Dendron Refactoring Commands](https://wiki.dendron.so/notes/srajljj10V2dl19nCSFiC/). This will ensure that any other impacted areas of the documentation, that link to or embed modified notes (via note references), are automatically updated.

Verify GitHub Actions tests are passing, which can be seen in the `Checks` tab of the PR:

- [ ] `URL validator` GitHub Action passes
- [ ] `Dendron site build` GitHub Action passes

> **NOTE:** If you are a new contributor, a maintainer will need to provide approval for GitHub Actions to run on your PRs.
