### PR TITLE
Update docs for Create Scratch Note keybinding change

### DIFF
--- a/vault/dendron.guides.troubleshooting.keyboard-shortcut-change.changelog.md
+++ b/vault/dendron.guides.troubleshooting.keyboard-shortcut-change.changelog.md
@@ -2,9 +2,8 @@
 id: 50kdbcwwda3gphjhccb0e5t
 title: Changelog
 desc: ''
-updated: 1662699737208
+updated: 1662733959150
 created: 1662695712727
-manager: [[user.hikchoi]]
 ---
 
 ## 2022-09-13

--- a/vault/dendron.guides.troubleshooting.keyboard-shortcut-change.changelog.md
+++ b/vault/dendron.guides.troubleshooting.keyboard-shortcut-change.changelog.md
@@ -1,0 +1,32 @@
+---
+id: 50kdbcwwda3gphjhccb0e5t
+title: Changelog
+desc: ''
+updated: 1662699737208
+created: 1662695712727
+manager: [[user.hikchoi]]
+---
+
+## 2022-09-13
+
+Default keyboard shortcut for [[dendron.topic.special-notes.commands.create-scratch-note]] has changed due to a conflict with the built-in VSCode keyboard shortcut for the command `File: Save As...` (command id: `workbench.action.files.saveAs`)
+
+- Original: 
+  - mac: `shift+cmd+s`
+  - windows: `shift+ctrl+s`
+- New:
+  - mac: `cmd+k s`
+  - windows: `ctrl+k s`
+
+To revert back to using the original keyboard shortcut,
+
+1. Open the command palette and run `Preferences: Open Keyboard Shortcuts (JSON)`
+2. Copy and paste the following JSON in to the opened file:
+> Note that this should be inserted between the square brackets.
+```
+  {
+    "command": "dendron.createScratchNote",
+    "key": "shift+cmd+s", // "shift+ctrl+s" if you are on a Windows system
+    "when": "dednron:pluginActive"
+  }
+```

--- a/vault/dendron.guides.troubleshooting.keyboard-shortcut-change.md
+++ b/vault/dendron.guides.troubleshooting.keyboard-shortcut-change.md
@@ -1,0 +1,33 @@
+---
+id: 2k083y52jny5grqgdbhlayw
+title: Keyboard Shortcut Change
+desc: 'Troubleshooting for keyboard shortcut related issues'
+updated: 1662709273426
+created: 1662694843326
+---
+
+## Summary
+
+{{fm.desc}}.
+
+## Customizing your keyboard shortcuts
+
+VSCode gives you the ability to change keyboard shortcuts that are built-in or contributed by extensions.
+
+To learn how you can change them, please see [[dendron.topic.keybindings]]
+
+## Requesting changes
+
+If you think a default keyboard shortcut that was added by Dendron conflicts with a very popular shortcut in VSCode, please feel free to open a request to change it in our [GitHub repository](https://github.com/dendronhq/dendron/issues/new/choose)
+
+We will keep track of the request and make decision based on the demand.
+
+## Troubleshooting changes to default keyboard shortcuts
+
+The VSCode ecosystem is full of extensions that each contribute many different keyboard shortcuts for their features.
+
+Dendron aims to provide a set of keyboard shortcuts with sensible defaults that doesn't clash with the frequently used keyboard shortcuts for VSCode users.
+
+In order to do this, sometimes we have to change existing keyboard shortcuts that are causing conflicts.
+
+Please check the list of changes [[here|dendron://dendron.dendron-site/dendron.guides.troubleshooting.keyboard-shortcut-change.changelog]] and follow the instructions for the particular changes.

--- a/vault/dendron.topic.keybindings.md
+++ b/vault/dendron.topic.keybindings.md
@@ -2,7 +2,7 @@
 id: c8e99b84-8a5a-42d3-838d-3d5cdebf32e5
 title: Keybindings
 desc: ''
-updated: 1616950201425
+updated: 1662695460482
 created: 1597950074331
 stub: false
 ---
@@ -17,7 +17,7 @@ To update your keybindings, open the command prompt and type `Open Keyboard Shor
 
 If you prefer to work with JSON, you can use `Open Keyboard Shortcuts (JSON)`.
 
-You can read more about keybinding syntax [here](https://code.visualstudio.com/docs/getstarted/keybindings)
+If you want to learn more about how keybindings work in VSCode, please read the official documents [here](https://code.visualstudio.com/docs/getstarted/keybindings)
 
 # Tips
 

--- a/vault/dendron.topic.special-notes.commands.create-scratch-note.md
+++ b/vault/dendron.topic.special-notes.commands.create-scratch-note.md
@@ -2,7 +2,7 @@
 id: z2gv1b7yc986fv93lunx6rc
 title: "Dendron: Create Scratch Note"
 desc: Create a scratch note
-updated: 1662097396698
+updated: 1662715199264
 created: 1661169226535
 ---
 
@@ -12,8 +12,8 @@ created: 1661169226535
 ![[dendron://dendron.dendron-site/dendron.topic.special-notes.scratch-note#summary,1]]
 
 ## Keybindings
-- windows: `ctrl+shift+s`
-- mac: `cmd+shift+s`
+- windows: `ctrl+k s`
+- mac: `cmd+k s`
 
 ## Details
 


### PR DESCRIPTION
## What does this PR do?
<!-- Describe pull request here. -->
- Update docs for Create Scratch Note keybinding change

## What issues does this PR fix or reference?
<!-- Delete section or leave empty if no related GitHub Issue exists -->

- Fixes:
OR
- Relates to: dendronhq/dendron#3502

> **NOTE:** `Fixes` will close the ticket after merging. `Relates to:` will leave the ticket open after merging.

### Merge requirements satisfied

> For more information, visit the [Contributing Guide for Documentation](https://wiki.dendron.so/notes/b58801fc-43a9-4d42-a58b-eabc3e8538cb/)

- [ ] Check rendered output to ensure formatting is correct for renderings of wikilinks, note refs, tables, and images. `Dendron: Show Preview` can be used in your workspace to confirm the page renders as expected. Sometimes, `Dendron: Reload Index` needs to be ran if certain wikilinks aren't working as expected. (ignore this if contribution is made via the `Edit this page on GitHub` button from the published site)
- [ ] If this PR includes any refactoring (renaming notes, renaming headers, etc.), make sure that these changes were done via [Dendron Refactoring Commands](https://wiki.dendron.so/notes/srajljj10V2dl19nCSFiC/). This will ensure that any other impacted areas of the documentation, that link to or embed modified notes (via note references), are automatically updated.

Verify GitHub Actions tests are passing, which can be seen in the `Checks` tab of the PR:

- [ ] `URL validator` GitHub Action passes
- [ ] `Dendron site build` GitHub Action passes

> **NOTE:** If you are a new contributor, a maintainer will need to provide approval for GitHub Actions to run on your PRs.
