### PR TITLE
Edited image topic doc to adhere to template

### DIFF
--- a/vault/dendron.topic.images.md
+++ b/vault/dendron.topic.images.md
@@ -2,7 +2,7 @@
 id: a91fd8da-6895-49fe-8164-a17acd8d9a17
 title: Images
 desc: ''
-updated: 1662866092517
+updated: 1662866892933
 created: 1595562035825
 ---
 ## Summary
@@ -17,7 +17,7 @@ Dendron extends regular Markdown image support by allowing custom CSS properties
 ## Features
 ### Copy & Paste
 
-Dendron automatically inserts images in your clipboard using the `> Paste Image` command. The image is saved to `${currentFileDir}/assets` by default. This feature requires the [Paste Image](https://link.dendron.so/vscode-paste-image) VS Code extension.
+Dendron automatically inserts images in your clipboard using the `> Paste Image` command. The image is saved to `${currentFileDir}/assets/images` by default. This feature requires the [Paste Image](https://link.dendron.so/vscode-paste-image) VS Code extension.
 
 <a href="https://www.loom.com/share/e1f6d207a1134f42b7a1a7750658acec">
 <img style="" src="https://cdn.loom.com/sessions/thumbnails/e1f6d207a1134f42b7a1a7750658acec-with-play.gif"> </a>
@@ -27,10 +27,9 @@ Dendron automatically inserts images in your clipboard using the `> Paste Image`
 
 An easy way to insert an image which is saved locally to your Markdown note is to do the following:
 
-- Copy / save the image in your `assets/images` folder located in your vault,
-- In Dendron navigate to the note where you wish to input the image(s), and type:
-- `![Image_Description](assets/images/File_Name.png)`
-  - Be sure to replace `Image_Description` and `File_Name.png` with the description of the image and the actual filename
+1. Copy / save the image in your `assets/images` folder located in your vault,
+2. In Dendron navigate to the note where you wish to input the image(s), and type:
+3. `![Image_Description](assets/images/File_Name.png)`. Be sure to replace `Image_Description` and `File_Name.png` with the description of the image and the actual filename
 
 ### Extended Images
 

--- a/vault/dendron.topic.images.md
+++ b/vault/dendron.topic.images.md
@@ -2,12 +2,20 @@
 id: a91fd8da-6895-49fe-8164-a17acd8d9a17
 title: Images
 desc: ''
-updated: 1659026813451
+updated: 1662866092517
 created: 1595562035825
-stub: false
 ---
-    
-## Copy & Paste
+## Summary
+
+Dendron extends regular Markdown image support by allowing custom CSS properties. Images can also be pasted into a file from your clipboard.
+
+## Use Cases
+
+* add images and screenshots to notes
+* modify images using inline YAML map
+
+## Features
+### Copy & Paste
 
 Dendron automatically inserts images in your clipboard using the `> Paste Image` command. The image is saved to `${currentFileDir}/assets` by default. This feature requires the [Paste Image](https://link.dendron.so/vscode-paste-image) VS Code extension.
 
@@ -15,7 +23,7 @@ Dendron automatically inserts images in your clipboard using the `> Paste Image`
 <img style="" src="https://cdn.loom.com/sessions/thumbnails/e1f6d207a1134f42b7a1a7750658acec-with-play.gif"> </a>
 </a>
 
-## Inserting Saved Images
+### Inserting Saved Images
 
 An easy way to insert an image which is saved locally to your Markdown note is to do the following:
 
@@ -24,13 +32,13 @@ An easy way to insert an image which is saved locally to your Markdown note is t
 - `![Image_Description](assets/images/File_Name.png)`
   - Be sure to replace `Image_Description` and `File_Name.png` with the description of the image and the actual filename
 
-## Extended Images
+### Extended Images
 
 Dendron allows you to extend your images by adding custom CSS properties to
 them. This can allow you to display an image at a specific size, make it float
 (text wrapping around image), add a border, or much more. Extended images work both in [[dendron://dendron.dendron-site/dendron.topic.preview]] and in [[Publishing|dendron.topic.publish]].
 
-### Syntax
+#### Syntax
 
 Extended images are the same as regular images, except that you add CSS properties at the end of it using an inline YAML map. This is simpler than it sounds, it looks like this:
 
@@ -84,6 +92,7 @@ This image should be floating to the left, and should have a 3-D effect on it! T
 
 One important thing in this example is the `transform: " ... "` part. Note the quotes: they are optional in most cases, but in complex cases they might be required. We don't have anything to warn you if your YAML is broken for now, but you can check the Preview V2, and the previewed image won't apply the CSS if it's broken.
 
+## Options 
 ### Allowed CSS properties
 
 For safety reasons, Dendron doesn't allow you to set just any CSS property. Here's a list of ones that are allowed:

--- a/vault/dendron.topic.images.md
+++ b/vault/dendron.topic.images.md
@@ -2,52 +2,28 @@
 id: a91fd8da-6895-49fe-8164-a17acd8d9a17
 title: Images
 desc: ''
-updated: 1662866892933
+updated: 1663207286049
 created: 1595562035825
 ---
 ## Summary
 
-Dendron extends regular Markdown image support by allowing custom CSS properties. Images can also be pasted into a file from your clipboard.
+Dendron extends regular Markdown image support by allowing custom CSS properties. Images can also be pasted into a note from your clipboard.
 
 ## Use Cases
 
-* add images and screenshots to notes
-* modify images using inline YAML map
+- copy/paste images into Markdown text
+- customize image size and styles using extended image link syntax
 
 ## Features
-### Copy & Paste
+### Copy & Paste Images into Plaintext
 
-Dendron automatically inserts images in your clipboard using the `> Paste Image` command. The image is saved to `${currentFileDir}/assets/images` by default. This feature requires the [Paste Image](https://link.dendron.so/vscode-paste-image) VS Code extension.
-
-<a href="https://www.loom.com/share/e1f6d207a1134f42b7a1a7750658acec">
-<img style="" src="https://cdn.loom.com/sessions/thumbnails/e1f6d207a1134f42b7a1a7750658acec-with-play.gif"> </a>
-</a>
-
-### Inserting Saved Images
-
-An easy way to insert an image which is saved locally to your Markdown note is to do the following:
-
-1. Copy / save the image in your `assets/images` folder located in your vault,
-2. In Dendron navigate to the note where you wish to input the image(s), and type:
-3. `![Image_Description](assets/images/File_Name.png)`. Be sure to replace `Image_Description` and `File_Name.png` with the description of the image and the actual filename
+Copy images into the text using the `> Paste Image` command. This command automatically copies an image from your clipboard to  `${currentFileDir}/assets/images` by default and adds a Markdown link to the image.
 
 ### Extended Images
 
 Dendron allows you to extend your images by adding custom CSS properties to
 them. This can allow you to display an image at a specific size, make it float
-(text wrapping around image), add a border, or much more. Extended images work both in [[dendron://dendron.dendron-site/dendron.topic.preview]] and in [[Publishing|dendron.topic.publish]].
-
-#### Syntax
-
-Extended images are the same as regular images, except that you add CSS properties at the end of it using an inline YAML map. This is simpler than it sounds, it looks like this:
-
-```
-![alt text (on mouse over)](/assets/image.png){width: 400px}
-```
-
-At the simplest, this can let you limit the width of the image. You can both set it to a fixed size like `400px`, or a ratio like `50%`.
-
-### Examples
+(text wrapping around image), add a border, or much more. Extended images work both in [[dendron://dendron.dendron-site/dendron.topic.preview]] and in [[Publishing|dendron.topic.publish]]. See the examples below:
 
 #### Sizing
 
@@ -111,3 +87,35 @@ For safety reasons, Dendron doesn't allow you to set just any CSS property. Here
 - z-index
 
 If these aren't enough for you, let us know by [sending a feature request](https://github.com/dendronhq/dendron/issues/new/choose) and we'll add it.
+
+## Getting Started
+### Link to Locally Saved Images
+
+An easy way to insert a locally saved image to your Markdown note is to do the following:
+
+1. Copy / save the image in your `assets/images` folder located in your vault,
+2. In Dendron navigate to the note where you wish to input the image(s), and type `![Image_Description](assets/images/File_Name.png)`. Be sure to replace `Image_Description` and `File_Name.png` with the description of the image and the actual filename
+3. Congratulations! You've inserted your first image.
+
+### Copy & Paste an image in Plaintext
+Dendron automatically inserts images in your clipboard using the `> Paste Image` command. The image is saved to `${currentFileDir}/assets/images` by default. This feature requires the [Paste Image](https://link.dendron.so/vscode-paste-image) VS Code extension.
+
+<a href="https://www.loom.com/share/e1f6d207a1134f42b7a1a7750658acec">
+<img style="" src="https://cdn.loom.com/sessions/thumbnails/e1f6d207a1134f42b7a1a7750658acec-with-play.gif"> </a>
+</a>
+
+### Syntax for Extending Images
+
+Extended images are the same as regular images, except that you add CSS properties at the end of it using an inline YAML map. This is simpler than it sounds, it looks like this:
+
+```
+![alt text (on mouse over)](/assets/image.png){width: 400px}
+```
+
+At the simplest, this can let you limit the width of the image. You can both set it to a fixed size like `400px`, or a ratio like `50%`.
+
+To add multiple properties to an image, separate the properties with commas. This should look like:
+
+```
+![alt text (on mouse over)](/assets/image.png){width: 400px, height: 200px}
+```

--- a/vault/templates.topic.md
+++ b/vault/templates.topic.md
@@ -24,7 +24,7 @@ See [[Top Level Feature|dendron://dendron.dendron-site/dendron.contribute.docume
 
 ## Use Cases
 {{! 
-See [[Use Cases|dendron://dendron.handbook/leaflet.journal.2022.05.10.standard-documentation.topics#use-cases]]
+See [[Use Cases|dendron://dendron.dendron-site/dendron.topic.templates#use-cases]]
 }}
 
 ### {usecase1}

--- a/vault/templates.topic.md
+++ b/vault/templates.topic.md
@@ -2,7 +2,7 @@
 id: ZljuAhFuNWEOUlFtPlC0h
 title: Feature Template
 desc: ''
-updated: 1658768084059
+updated: 1663101445929
 created: 1635992238170
 config:
   global:
@@ -24,7 +24,7 @@ See [[Top Level Feature|dendron://dendron.dendron-site/dendron.contribute.docume
 
 ## Use Cases
 {{! 
-See [[Use Cases|dendron://dendron.dendron-site/dendron.topic.templates#use-cases]]
+See [[Use Cases|dendron://dendron.handbook/leaflet.journal.2022.05.10.standard-documentation.topics#use-cases]]
 }}
 
 ### {usecase1}


### PR DESCRIPTION
## What does this PR do?
Updates [Images](https://github.com/dendronhq/dendron-site/blob/master/vault/dendron.topic.images.md) to adhere to the [topic template](https://github.com/dendronhq/dendron-site/blob/master/vault/templates.topic.md).

- Fixes:
OR
- Relates to:

> **NOTE:** `Fixes` will close the ticket after merging. `Relates to:` will leave the ticket open after merging.

### Merge requirements satisfied

> For more information, visit the [Contributing Guide for Documentation](https://wiki.dendron.so/notes/b58801fc-43a9-4d42-a58b-eabc3e8538cb/)

- [x] Check rendered output to ensure formatting is correct for renderings of wikilinks, note refs, tables, and images. `Dendron: Show Preview` can be used in your workspace to confirm the page renders as expected. Sometimes, `Dendron: Reload Index` needs to be ran if certain wikilinks aren't working as expected. (ignore this if contribution is made via the `Edit this page on GitHub` button from the published site)
- [x] If this PR includes any refactoring (renaming notes, renaming headers, etc.), make sure that these changes were done via [Dendron Refactoring Commands](https://wiki.dendron.so/notes/srajljj10V2dl19nCSFiC/). This will ensure that any other impacted areas of the documentation, that link to or embed modified notes (via note references), are automatically updated.

Verify GitHub Actions tests are passing, which can be seen in the `Checks` tab of the PR:

- [ ] `URL validator` GitHub Action passes
- [x] `Dendron site build` GitHub Action passes

> **NOTE:** If you are a new contributor, a maintainer will need to provide approval for GitHub Actions to run on your PRs.
