### PR TITLE
"dendron" misspelled in "when" clause

### DIFF
--- a/vault/dendron.guides.troubleshooting.keyboard-shortcut-change.changelog.md
+++ b/vault/dendron.guides.troubleshooting.keyboard-shortcut-change.changelog.md
@@ -26,6 +26,6 @@ To revert back to using the original keyboard shortcut,
   {
     "command": "dendron.createScratchNote",
     "key": "shift+cmd+s", // "shift+ctrl+s" if you are on a Windows system
-    "when": "dednron:pluginActive"
+    "when": "dendron:pluginActive"
   }
 ```


### PR DESCRIPTION
## What does this PR do?
<!-- Describe pull request here. -->

## What issues does this PR fix or reference?
<!-- Delete section or leave empty if no related GitHub Issue exists -->

- Fixes: A small spelling mistake in "when" clause, that would create an error in the config.
OR
- Relates to:

> **NOTE:** `Fixes` will close the ticket after merging. `Relates to:` will leave the ticket open after merging.

### Merge requirements satisfied

> For more information, visit the [Contributing Guide for Documentation](https://wiki.dendron.so/notes/b58801fc-43a9-4d42-a58b-eabc3e8538cb/)

- [x] Check rendered output to ensure formatting is correct for renderings of wikilinks, note refs, tables, and images. `Dendron: Show Preview` can be used in your workspace to confirm the page renders as expected. Sometimes, `Dendron: Reload Index` needs to be ran if certain wikilinks aren't working as expected. (ignore this if contribution is made via the `Edit this page on GitHub` button from the published site)
- [x] If this PR includes any refactoring (renaming notes, renaming headers, etc.), make sure that these changes were done via [Dendron Refactoring Commands](https://wiki.dendron.so/notes/srajljj10V2dl19nCSFiC/). This will ensure that any other impacted areas of the documentation, that link to or embed modified notes (via note references), are automatically updated.

Verify GitHub Actions tests are passing, which can be seen in the `Checks` tab of the PR:

- [x] `URL validator` GitHub Action passes
- [x] `Dendron site build` GitHub Action passes

> **NOTE:** If you are a new contributor, a maintainer will need to provide approval for GitHub Actions to run on your PRs.
