### PR TITLE
Add notes for 2022-09-30 greenhouse talk

### DIFF
--- a/vault/community.events.greenhouse.2022-09-30-zettlekasten-101.md
+++ b/vault/community.events.greenhouse.2022-09-30-zettlekasten-101.md
@@ -1,0 +1,21 @@
+---
+id: pjaaevqw5v3jnalgal58cid
+title: 'September Greenhouse: Zettlekasten 101 with Bob Doto'
+desc: >-
+  In this presentation, Bob Doto covers the basic terminology, methods, and ways
+  of getting started with a zettelkasten.
+updated: 1665155660082
+created: 1665155192086
+---
+
+## Summary
+
+{{fm.desc}}
+
+## Video
+
+<iframe width="640" height="360" src="https://www.youtube.com/embed/9fP4zFQMXSw" title="Greenhouse September 2022 - Zettlekasten 101 with Bob Doto" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
+## Lookup
+
+For more of Bob Doto's writing on zettlekasten, refer to: <https://writing.bobdoto.computer/zettelkasten/>


### PR DESCRIPTION
This PR adds basic notes and a video embed for the September 2022 edition of the Greenhouse talk series to the Dendron site.