### PR TITLE
chore: enable giscus widgets

### DIFF
--- a/dendron.yml
+++ b/dendron.yml
@@ -16,7 +16,8 @@ commands:
         enableMultiSelect: false
     insertNoteIndex:
         enableMarker: false
-    copyNoteLink: {}
+    copyNoteLink:
+        aliasMode: title
     templateHierarchy: template
 workspace:
     dendronVersion: 0.83.0
@@ -37,7 +38,6 @@ workspace:
         zoomSpeed: 1
         createStub: false
     enableAutoCreateOnDefinition: false
-    enableHandlebarTemplates: true
     enableXVaultWikiLink: true
     enableRemoteVaultInit: true
     workspaceVaultSyncMode: noCommit
@@ -71,11 +71,9 @@ workspace:
     enableHashTags: true
     enableEditorDecorations: true
     enableFullHierarchyNoteTitle: false
-    enableSmartRefs: false
 preview:
     enableFMTitle: true
     enableNoteTitleForLink: true
-    enableMermaid: true
     enablePrettyRefs: true
     enableKatex: true
     automaticallyShowPreview: false
@@ -84,7 +82,6 @@ preview:
 publishing:
     enableFMTitle: true
     enableNoteTitleForLink: true
-    enableMermaid: true
     enablePrettyRefs: true
     enableKatex: true
     copyAssets: true
@@ -106,7 +103,7 @@ publishing:
     enableHashesForFMTags: false
     enableRandomlyColoredTags: true
     writeStubs: false
-    siteBanner: "custom"
+    siteBanner: custom
     seo:
         title: Dendron
         description: >-
@@ -116,8 +113,9 @@ publishing:
         author: dendronhq
         twitter: dendronhq
         image:
-          url: https://foundation-prod-assetspublic53c57cce-8cpvgjldwysl.s3-us-west-2.amazonaws.com/assets/logo-256.png
-          alt: Dendron
+            url: >-
+                https://foundation-prod-assetspublic53c57cce-8cpvgjldwysl.s3-us-west-2.amazonaws.com/assets/logo-256.png
+            alt: Dendron
     github:
         cname: wiki.dendron.so
         enableEditLink: true
@@ -127,3 +125,22 @@ publishing:
         editRepository: https://github.com/dendronhq/dendron-site
     enablePrettyLinks: true
     enableTaskNotes: true
+    hierarchy:
+        dendron:
+            customFrontmatter:
+                -
+                    key: enableGiscus
+                    value: true
+    giscus:
+        repo: dendronhq/dendron-site
+        repoId: MDEwOlJlcG9zaXRvcnkyODAyMjc1NTU=
+        category: Announcements
+        categoryId: DIC_kwDOELPu484CR5V2
+        mapping: pathname
+        theme: preferred_color_scheme
+        strict: '0'
+        reactionsEnabled: '1'
+        emitMetadata: '0'
+        inputPosition: top
+        lang: en
+        loading: lazy

--- a/package.json
+++ b/package.json
@@ -7,6 +7,6 @@
         "dendron": "dendron-cli"
     },
     "dependencies": {
-        "@dendronhq/dendron-cli": "^0.106.0"
+        "@dendronhq/dendron-cli": "latest"
     }
 }


### PR DESCRIPTION
## What does this PR do?
This enables the Giscus widget on all pages under the `dendron.*` hierarchy

## What issues does this PR fix or reference?
<!-- Delete section or leave empty if no related GitHub Issue exists -->

- Fixes:
OR
- Relates to:

> **NOTE:** `Fixes` will close the ticket after merging. `Relates to:` will leave the ticket open after merging.

### Merge requirements satisfied

> For more information, visit the [Contributing Guide for Documentation](https://wiki.dendron.so/notes/b58801fc-43a9-4d42-a58b-eabc3e8538cb/)

- [ ] Check rendered output to ensure formatting is correct for renderings of wikilinks, note refs, tables, and images. `Dendron: Show Preview` can be used in your workspace to confirm the page renders as expected. Sometimes, `Dendron: Reload Index` needs to be ran if certain wikilinks aren't working as expected. (ignore this if contribution is made via the `Edit this page on GitHub` button from the published site)
- [ ] If this PR includes any refactoring (renaming notes, renaming headers, etc.), make sure that these changes were done via [Dendron Refactoring Commands](https://wiki.dendron.so/notes/srajljj10V2dl19nCSFiC/). This will ensure that any other impacted areas of the documentation, that link to or embed modified notes (via note references), are automatically updated.

Verify GitHub Actions tests are passing, which can be seen in the `Checks` tab of the PR:

- [ ] `URL validator` GitHub Action passes
- [ ] `Dendron site build` GitHub Action passes

> **NOTE:** If you are a new contributor, a maintainer will need to provide approval for GitHub Actions to run on your PRs.
