### PR TITLE
Adjust spaces in dendron.tutorial.taking-notes.md

### DIFF
--- a/vault/dendron.tutorial.taking-notes.md
+++ b/vault/dendron.tutorial.taking-notes.md
@@ -4,7 +4,7 @@ title: Taking Notes
 desc: >-
   Creating notes, understanding hierarchy, and using Lookup to quickly find your
   notes
-updated: 1645804032664
+updated: 1670372812493
 created: 1625563944736
 nav_order: 1
 ---
@@ -46,7 +46,7 @@ You can add metadata information to your note using frontmatter attributes.
 ![[dendron://dendron.dendron-site/dendron.topic.hierarchies#summary,1:#concepts]]
 To create a hierarchy, do the following:
 1. Enter `Ctrl+L` / `Cmd+L` to open the lookup bar. 
-2. Enter a name with  a `.` ("dot") delimiter.  For example, you can type `recipes.vegetarian` to create a note to store your vegetarian recipes.
+2. Enter a name with a `.` ("dot") delimiter. For example, you can type `recipes.vegetarian` to create a note to store your vegetarian recipes.
 3. Press **Enter**.
 You've created your first hierarchy! 
 
@@ -90,7 +90,7 @@ To find your notes, do the following:
 2. Enter the name of your note. For example, you can type `vege` to find your `recipes.vegetarian` note.
 3. Press **Enter**. The note is opened.
 
-> 💡 **INFO:** Lookup uses _fuzzy search_, which means you can type out partial queries and still see the  results.Entering multiple keywords delimited by space will lookup matching notes regardless of order of the > keywords.
+> 💡 **INFO:** Lookup uses _fuzzy search_, which means you can type out partial queries and still see the results. Entering multiple keywords delimited by space will lookup matching notes regardless of order of the > keywords.
 > - Example: `vege rec` or `rec vege` will match the `recipes.vegetarian` note.
 
 > 💡 **TIP:** Read [[dendron://dendron.dendron-site/dendron.topic.lookup.find]] to understand the different ways of querying the lookup.


### PR DESCRIPTION
## What does this PR do?
<!-- Describe pull request here. -->
Fix some weird additional/missing spaces in the tutorial note (which I am looking through at the moment:)

The updated attribute in the frontmatter automatically updates after I made the change, not sure if this is ok or should be reverted.

### Merge requirements satisfied

> For more information, visit the [Contributing Guide for Documentation](https://wiki.dendron.so/notes/b58801fc-43a9-4d42-a58b-eabc3e8538cb/)

- [x] Check rendered output to ensure formatting is correct for renderings of wikilinks, note refs, tables, and images. `Dendron: Show Preview` can be used in your workspace to confirm the page renders as expected. Sometimes, `Dendron: Reload Index` needs to be ran if certain wikilinks aren't working as expected. (ignore this if contribution is made via the `Edit this page on GitHub` button from the published site)
- [ ] If this PR includes any refactoring (renaming notes, renaming headers, etc.), make sure that these changes were done via [Dendron Refactoring Commands](https://wiki.dendron.so/notes/srajljj10V2dl19nCSFiC/). This will ensure that any other impacted areas of the documentation, that link to or embed modified notes (via note references), are automatically updated.

Verify GitHub Actions tests are passing, which can be seen in the `Checks` tab of the PR:

- [ ] `URL validator` GitHub Action passes
- [ ] `Dendron site build` GitHub Action passes

> **NOTE:** If you are a new contributor, a maintainer will need to provide approval for GitHub Actions to run on your PRs.
