### PR TITLE
Rectify example for CURRENT_DAY_OF_WEEK template

### DIFF
--- a/vault/dendron.topic.templates.template-variables.md
+++ b/vault/dendron.topic.templates.template-variables.md
@@ -24,7 +24,7 @@ You can apply template variables by using the following syntax: `{{ VARIABLE }}`
 - `CURRENT_QUARTER`: The current quarter as one-indexed single digit number (example: `1` for first quarter)
 - `CURRENT_MONTH_NAME`: The month as string name (example: `January`)
 - `CURRENT_MONTH_NAME_SHORT`: The month as abbreviated string name (example: `Jan` for January)
-- `CURRENT_DAY_OF_WEEK`: equivalent of [javascript getDay](https://www.w3schools.com/jsref/jsref_getday.asp) method (example: `3` for Monday)
+- `CURRENT_DAY_OF_WEEK`: equivalent of [javascript getDay](https://www.w3schools.com/jsref/jsref_getday.asp) method (example: `3` for Wednesday)
 - `CURRENT_DAY_OF_WEEK_ABBR`: The day of week, as an abbreviated localized string (example: `Wed` for Wednesday)
 - `CURRENT_DAY_OF_WEEK_FULL` The day of week, as an unabbreviated localized string (example: `Wednesday`),
 - `CURRENT_DAY_OF_WEEK_SINGLE` (example: `W` for Wednesday),


### PR DESCRIPTION

## What does this PR do?

Fixes an inaccurate example.

This contribution was made via the `Edit this page on GitHub` button and is my first pull request. My apologies; I don't know how to verify GitHub Actions tests are passing, and I do not see a `Checks` tab of the PR.


### Merge requirements satisfied

> For more information, visit the [Contributing Guide for Documentation](https://wiki.dendron.so/notes/b58801fc-43a9-4d42-a58b-eabc3e8538cb/)

- [ ] Check rendered output to ensure formatting is correct for renderings of wikilinks, note refs, tables, and images. `Dendron: Show Preview` can be used in your workspace to confirm the page renders as expected. Sometimes, `Dendron: Reload Index` needs to be ran if certain wikilinks aren't working as expected. (ignore this if contribution is made via the `Edit this page on GitHub` button from the published site)
- [ ] If this PR includes any refactoring (renaming notes, renaming headers, etc.), make sure that these changes were done via [Dendron Refactoring Commands](https://wiki.dendron.so/notes/srajljj10V2dl19nCSFiC/). This will ensure that any other impacted areas of the documentation, that link to or embed modified notes (via note references), are automatically updated.

Verify GitHub Actions tests are passing, which can be seen in the `Checks` tab of the PR:

- [ ] `URL validator` GitHub Action passes
- [ ] `Dendron site build` GitHub Action passes

> **NOTE:** If you are a new contributor, a maintainer will need to provide approval for GitHub Actions to run on your PRs.
