### PR TITLE
Update shortcuts in dendron.guides.tips.md

### DIFF
--- a/vault/dendron.guides.tips.md
+++ b/vault/dendron.guides.tips.md
@@ -20,7 +20,7 @@ It is possible to [peek](https://code.visualstudio.com/docs/editor/editingevolve
 
 ### Moving Lines
 
-When working with lines, you can move entire lines at a time using `option-up|down` shortcut on mac. This is really helpful for prioritizing todos among other things ✅
+When working with lines, you can move entire lines at a time using the shortcut `option-up|down` on Mac or `alt-up|down` on Windows. This is really helpful for prioritizing todos among other things ✅
 
 ![](https://foundation-prod-assetspublic53c57cce-8cpvgjldwysl.s3-us-west-2.amazonaws.com/assets/images/tips-move-lines.gif)
 
@@ -211,7 +211,8 @@ You can move VS Code tabs using the following builtin commands:
 - `View: Move Editor Into Previous Group`
 
 They are mapped on to the following keyboard shortcuts:
-- mac: `cmd+ctrl+left|right`
+- Mac: `cmd+ctrl+left|right`
+- Windows: `ctrl+alt+left|right`
 
 This is helpful for looking at your notes side by side. 
 


### PR DESCRIPTION
## What does this PR do?
- Add Windows equivalent shortcuts for Mac commands
- Capitalize Mac and Windows in modified sections

### Merge requirements satisfied

- [ ] Check rendered output to ensure formatting is correct for renderings of wikilinks, note refs, tables, and images. `Dendron: Show Preview` can be used in your workspace to confirm the page renders as expected. Sometimes, `Dendron: Reload Index` needs to be ran if certain wikilinks aren't working as expected. (ignore this if contribution is made via the `Edit this page on GitHub` button from the published site)
- [ ] If this PR includes any refactoring (renaming notes, renaming headers, etc.), make sure that these changes were done via [Dendron Refactoring Commands](https://wiki.dendron.so/notes/srajljj10V2dl19nCSFiC/). This will ensure that any other impacted areas of the documentation, that link to or embed modified notes (via note references), are automatically updated.

Verify GitHub Actions tests are passing, which can be seen in the `Checks` tab of the PR:

- [ ] `URL validator` GitHub Action passes
- [ ] `Dendron site build` GitHub Action passes
